### PR TITLE
original_filename now stored in adminMetadata using premis:hasOriginalNa...

### DIFF
--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "grouper-rest-client"
   s.add_dependency "ezid-client", "~> 0.9"
   s.add_dependency "resque", "~> 1.25"
+  s.add_dependency "rdf-vocab", "~> 0.4"
 
   s.add_development_dependency "bundler", "~> 1.7"
   s.add_development_dependency "rake"

--- a/lib/ddr/datastreams/admin_metadata_datastream.rb
+++ b/lib/ddr/datastreams/admin_metadata_datastream.rb
@@ -1,10 +1,12 @@
+require "rdf-vocab"
+
 module Ddr
   module Datastreams
     class AdminMetadataDatastream < ActiveFedora::NtriplesRDFDatastream
 
       property :permanent_id, predicate: Ddr::Vocab::Asset.permanentId
-
       property :permanent_url, predicate: Ddr::Vocab::Asset.permanentUrl
+      property :original_filename, predicate: RDF::Vocab::PREMIS::V1.hasOriginalName
 
       Ddr::Vocab::Roles.each do |term|
         property Ddr::Metadata::Vocabulary.term_name(Ddr::Vocab::Roles, term), 

--- a/lib/ddr/models/has_content.rb
+++ b/lib/ddr/models/has_content.rb
@@ -11,7 +11,7 @@ module Ddr
                             label: "Content file for this object",
                             control_group: "M"
 
-        has_attributes :original_filename, datastream: "properties", multiple: false
+        has_attributes :original_filename, datastream: "adminMetadata", multiple: false
 
         include Hydra::Derivatives
         include FileManagement unless include?(FileManagement)


### PR DESCRIPTION
...me predicate.

Closes #85
This change clears the way to remove the properties datastream and may help with
Fedora 4 migration since Fedora 4 stores the original name of a binary file under
the same predicate.