### PR TITLE
Upgraded devise-remote-user to ~> 0.5.0 to get the `login_url` setting.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ APP_ROOT = File.dirname(__FILE__)
 JETTY_CONFIG = { 
 	jetty_home: File.join(APP_ROOT, "jetty"),
 	jetty_port: 8983,
-	startup_wait: 45,
+	startup_wait: 60,
 	quiet: true,
 	java_opts: ["-Xmx256m", "-XX:MaxPermSize=128m"]
 }

--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "hydra-derivatives"
   s.add_dependency "hydra-validations"
   s.add_dependency "ddr-antivirus", "~> 1.3.1"
-  s.add_dependency "devise-remote-user"
+  s.add_dependency "devise-remote-user", "~> 0.5"
   s.add_dependency "grouper-rest-client"
   s.add_dependency "ezid-client", "~> 0.9"
   s.add_dependency "resque", "~> 1.25"
@@ -35,6 +35,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 3.1"
   s.add_development_dependency "factory_girl_rails", "~> 4.4"
-  s.add_development_dependency "jettywrapper"
+  s.add_development_dependency "jettywrapper", "~> 1.8"
   s.add_development_dependency "database_cleaner"
 end

--- a/lib/ddr/models/engine.rb
+++ b/lib/ddr/models/engine.rb
@@ -42,6 +42,7 @@ module Ddr
           }
           config.auto_update = true
           config.logout_url = "/Shibboleth.sso/Logout?return=https://shib.oit.duke.edu/cgi-bin/logout.pl"
+          config.login_url = Proc.new { |env| "/Shibboleth.sso/Login?target=#{env['REQUEST_URI']}" }
         end
       end
 


### PR DESCRIPTION
Set `DeviseRemoteUser.login_url` to a Proc which resolves to a URL
for logging into Shib and returning to the previous URL (REQUEST_URI).