### PR TITLE
Added I18n config to support labels for groups

### DIFF
--- a/config/locales/groups.en.yml
+++ b/config/locales/groups.en.yml
@@ -1,0 +1,6 @@
+en:
+  groups:
+    public: Public
+    registered: Duke Community
+# Grouper group example:
+#    "duke:library:repository:ddr:archivists": Archivists          


### PR DESCRIPTION
This is a light weight solution motivated by the use of Grouper groups.  While a static file initially duplicates Grouper data, it establishes the pattern and could be overridden by dynamically updated files on the server.