### PR TITLE
Adds user_key to events in order to decouple events from users.

### DIFF
--- a/db/migrate/20150130134416_add_user_key_to_events.rb
+++ b/db/migrate/20150130134416_add_user_key_to_events.rb
@@ -1,0 +1,7 @@
+class AddUserKeyToEvents < ActiveRecord::Migration
+  def change
+    change_table :events do |t|
+      t.string :user_key
+    end
+  end
+end

--- a/lib/ddr/auth/ability.rb
+++ b/lib/ddr/auth/ability.rb
@@ -33,7 +33,6 @@ module Ddr
       end
 
       def events_permissions
-        can :read, Ddr::Events::Event, user: current_user
         can :read, Ddr::Events::Event do |e|
           can? :read, e.pid
         end

--- a/lib/ddr/events/event.rb
+++ b/lib/ddr/events/event.rb
@@ -28,7 +28,7 @@ module Ddr
       # For rendering "performed by" when no associated user
       SYSTEM = "SYSTEM"
 
-      DDR_SOFTWARE = "DDR #{Ddr::Models::VERSION}"
+      DDR_SOFTWARE = "ddr-models #{Ddr::Models::VERSION}"
 
       class_attribute :description
   
@@ -70,7 +70,7 @@ module Ddr
       end
   
       def performed_by
-        user ? user.to_s : SYSTEM
+        user_key || SYSTEM
       end
 
       def comment_or_summary
@@ -99,6 +99,12 @@ module Ddr
 
       def object
         @object ||= ActiveFedora::Base.find(pid) if pid
+      end
+
+      # Sets user_key to user.user_key
+      # For compatibility with ddr-models <= 1.9.0
+      def user=(user)
+        self.user_key = user.user_key
       end
 
       def object=(obj)
@@ -157,7 +163,7 @@ module Ddr
       end
 
       def default_summary
-        self.class.description
+        description
       end
 
       def default_event_date_time

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150110023410) do
+ActiveRecord::Schema.define(version: 20150130134416) do
 
   create_table "events", force: true do |t|
     t.datetime "event_date_time"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20150110023410) do
     t.string   "outcome"
     t.text     "detail"
     t.string   "exception"
+    t.string   "user_key"
   end
 
   add_index "events", ["event_date_time"], name: "index_events_on_event_date_time"

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -10,10 +10,12 @@ module Ddr
 
       describe "collection permissions" do
         before { allow(Ddr::Auth).to receive(:collection_creators_group) { "Collection Creators" } }
+
         context "user is a collection creator" do
           before { allow(user).to receive(:groups) { ["Collection Creators"] } }
           it { is_expected.to be_able_to(:create, Collection) }
         end
+
         context "user is not a collection creator" do
           it { is_expected.not_to be_able_to(:create, Collection) }
         end
@@ -21,10 +23,12 @@ module Ddr
 
       describe "#upload_permissions", uploads: true do
         let(:resource) { FactoryGirl.build(:component) }
+
         context "user has edit permission" do
           before { subject.can(:edit, resource) }
           it { is_expected.to be_able_to(:upload, resource) }
         end
+
         context "user does not have edit permission" do
           before { subject.cannot(:edit, resource) }
           it { is_expected.not_to be_able_to(:upload, resource) }
@@ -32,64 +36,84 @@ module Ddr
       end
 
       describe "#download_permissions", downloads: true do
+
         context "on an object" do
+
           context "which is a Component", components: true do
-            let!(:resource) { FactoryGirl.create(:component) }
+            let(:resource) { Component.new(pid: "test:1") }
+
             context "and user does NOT have the downloader role" do
+              before do
+                allow(subject.current_user).to receive(:has_role?).with(resource, :downloader) { false }
+              end
+
               context "and user has edit permission" do
-                before do
-                  resource.edit_users = [user.user_key]
-                  resource.save
-                end
+                before { subject.can :edit, resource }
                 it { is_expected.to be_able_to(:download, resource) }
               end
+
               context "and user has read permission" do
                 before do
-                  resource.read_users = [user.user_key]
-                  resource.save
+                  subject.cannot :edit, resource
+                  subject.can :read, resource
                 end
                 it { is_expected.not_to be_able_to(:download, resource) }
               end
+
               context "and user lacks read permission" do
+                before do
+                  subject.cannot :edit, resource
+                  subject.cannot :read, resource
+                end
                 it { is_expected.not_to be_able_to(:download, resource) }
               end
             end
+
             # Component
             context "and user has the downloader role", roles: true do
               before do
-                resource.roles.downloader << user.principal_name
-                resource.save
+                allow(subject.current_user).to receive(:has_role?).with(resource, :downloader) { true }
               end
+
               context "and user has edit permission" do
-                before do
-                  resource.edit_users = [user.user_key]
-                  resource.save
-                end
+                before { subject.can :edit, resource }
                 it { is_expected.to be_able_to(:download, resource) }
               end
+
               context "and user has read permission" do
                 before do
-                  resource.read_users = [user.user_key]
-                  resource.save
+                  subject.cannot :edit, resource
+                  subject.can :read, resource
                 end
                 it { is_expected.to be_able_to(:download, resource) }
               end
+
               context "and user lacks read permission" do
+                before do
+                  subject.cannot :edit, resource
+                  subject.cannot :read, resource
+                end
                 it { is_expected.not_to be_able_to(:download, resource) }
               end          
             end
           end
 
           context "which is not a Component" do
-            let(:resource) { FactoryGirl.create(:test_content) }
+            let(:resource) { FactoryGirl.build(:test_content) }
+
             context "and user has read permission" do
               before do
-                resource.read_users = [user.user_key]
-                resource.save
+                subject.cannot :edit, resource
+                subject.can :read, resource
               end
               it { is_expected.to be_able_to(:download, resource) }
             end
+
             context "and user lacks read permission" do
+              before do
+                subject.cannot :edit, resource
+                subject.cannot :read, resource
+              end
               it { is_expected.not_to be_able_to(:download, resource) }
             end                  
           end
@@ -97,45 +121,58 @@ module Ddr
 
         context "on a Solr document" do
           let(:resource) { SolrDocument.new(doc) }
+
           context "for a Component" do
             let(:doc) { {'id'=>'test:1', 'active_fedora_model_ssi'=>'Component'} }
+
             context "on which the user has the downloader role" do
               before { doc.merge!('admin_metadata__downloader_ssim'=>[user.to_s]) }
+
               context "but does not have read permission" do
                 it { is_expected.not_to be_able_to(:download, resource) }
               end
+
               context "and has read permission" do
                 before { doc.merge!('read_access_person_ssim'=>[user.to_s]) }
                 it { is_expected.to be_able_to(:download, resource) }
               end
+
               context "and has edit permission" do
                 before { doc.merge!('edit_access_person_ssim'=>[user.to_s]) }
                 it { is_expected.to be_able_to(:download, resource) }
               end
             end
+
             context "on which the user does NOT have the downloader role" do
+
               context "and does not have read permission" do
                 it { is_expected.not_to be_able_to(:download, resource) }
               end
+
               context "but has read permission" do
                 before { doc.merge!('read_access_person_ssim'=>[user.to_s]) }
                 it { is_expected.not_to be_able_to(:download, resource) }
               end
+
               context "but has edit permission" do
                 before { doc.merge!('edit_access_person_ssim'=>[user.to_s]) }
                 it { is_expected.to be_able_to(:download, resource) }
               end              
             end
           end
+
           context "for a non-Component" do
             let(:doc) { {'id'=>'test:1', 'active_fedora_model_ssi'=>'Attachment'} }
+
             context "on which the user does NOT have read permission" do
               it { is_expected.not_to be_able_to(:download, resource) }
             end
+
             context "on which the user has read permission" do
               before { doc.merge!('read_access_person_ssim'=>[user.to_s]) }
               it { is_expected.to be_able_to(:download, resource) }
             end
+
             context "on which the user has edit permission" do
               before { doc.merge!('edit_access_person_ssim'=>[user.to_s]) }
               it { is_expected.to be_able_to(:download, resource) }
@@ -144,51 +181,63 @@ module Ddr
         end
 
         context "on a datastream", datastreams: true do
+
           context "named 'content'", content: true do
             let(:resource) { obj.content }
+            let(:solr_doc) { SolrDocument.new({id: obj.pid}) }
+            before do
+              allow(subject).to receive(:solr_doc).with(obj.pid) { solr_doc }
+              subject.cannot :edit, obj.pid 
+            end
+
             context "and object is a Component", components: true do
-              let(:obj) { FactoryGirl.create(:component) }
-              context "and user does not have the downloader role" do
+              let(:obj) { Component.new(pid: "test:1") }
+
+              context "and user does not have the downloader role" do            
+                before do
+                  allow(subject.current_user).to receive(:has_role?).with(solr_doc, :downloader) { false } 
+                end
+
                 context "and user has read permission on the object" do
-                  before do
-                    obj.read_users = [user.user_key]
-                    obj.save
-                  end
+                  before { subject.can :read, obj.pid }
                   it { is_expected.not_to be_able_to(:download, resource) }
                 end
+
                 context "and user lacks read permission on the object" do
+                  before { subject.cannot :read, obj.pid }
                   it { is_expected.not_to be_able_to(:download, resource) }
                 end
               end
+
               # Component content datastream
               context "and user has the downloader role", roles: true do
                 before do
-                  obj.roles.downloader << user.principal_name
-                  obj.save
+                  allow(subject.current_user).to receive(:has_role?).with(solr_doc, :downloader) { true } 
                 end
+
                 context "and user has read permission on the object" do
-                  before do
-                    obj.read_users = [user.user_key]
-                    obj.save
-                  end
+                  before { subject.can :read, obj.pid }
                   it { is_expected.to be_able_to(:download, resource) }
                 end
+
                 context "and user lacks read permission on the object" do
+                  before { subject.cannot :read, obj.pid }
                   it { is_expected.not_to be_able_to(:download, resource) }
                 end          
               end
             end
+
             # non-Component content datastream
             context "and object is not a Component" do
-              let(:obj) { FactoryGirl.create(:test_content) }
+              let(:obj) { TestContent.new(pid: "test:1") }
+
               context "and user has read permission on the object" do
-                before do
-                  obj.read_users = [user.user_key]
-                  obj.save
-                end
+                before { subject.can :read, obj.pid }
                 it { is_expected.to be_able_to(:download, resource) }
               end
+
               context "and user lacks read permission on the object" do
+                before { subject.cannot :read, obj.pid }
                 it { is_expected.not_to be_able_to(:download, resource) }
               end                  
             end
@@ -196,16 +245,22 @@ module Ddr
           end
           # datastream - not "content"
           context "not named 'content'" do
-            let(:obj) { FactoryGirl.create(:test_model) }
+            let(:obj) { FactoryGirl.build(:test_model) }
             let(:resource) { obj.descMetadata }
+
             context "and user has read permission on the object" do
               before do
-                obj.read_users = [user.user_key]
-                obj.save
+                subject.cannot :edit, obj.pid 
+                subject.can :read, obj.pid 
               end
               it { is_expected.to be_able_to(:download, resource) }
             end
+
             context "and user lacks read permission on the object" do
+              before do
+                subject.cannot :edit, obj.pid 
+                subject.cannot :read, obj.pid 
+              end
               it { is_expected.not_to be_able_to(:download, resource) }
             end        
           end
@@ -219,38 +274,35 @@ module Ddr
       end
 
       describe "#events_permissions", events: true do
-        let(:object) { FactoryGirl.create(:test_model) }
-        let(:resource) { Ddr::Events::Event.new(pid: object.pid) }
-        context "event is associated with a user" do
-          before { resource.user = user }
+        let(:resource) { Ddr::Events::Event.new(pid: "test:1") }
+
+        context "when the user can read the object" do
+          before { subject.can :read, "test:1" }
           it { is_expected.to be_able_to(:read, resource) }
         end
-        context "event is not associated with a user" do      
-          context "and can read object" do
-            before do
-              object.read_users = [user.user_key]
-              object.save!
-            end
-            it { is_expected.to be_able_to(:read, resource) }
-          end
-          context "and cannot read object" do
-            it { is_expected.not_to be_able_to(:read, resource) }
-          end
+
+        context "when the user cannot read the object" do
+          before { subject.cannot :read, "test:1" }
+          it { is_expected.not_to be_able_to(:read, resource) }
         end
       end
 
       describe "#attachment_permissions", attachments: true do
+
         context "object can have attachments" do
           let(:resource) { FactoryGirl.build(:test_model_omnibus) }
+
           context "and user lacks edit rights" do
             before { subject.cannot(:edit, resource) }
             it { is_expected.not_to be_able_to(:add_attachment, resource) }
           end
+
           context "and user has edit rights" do
             before { subject.can(:edit, resource) }
             it { is_expected.to be_able_to(:add_attachment, resource) }
           end
         end
+
         context "object cannot have attachments" do
           let(:resource) { FactoryGirl.build(:test_model) }
           before { subject.can(:edit, resource) }
@@ -259,17 +311,21 @@ module Ddr
       end
 
       describe "#children_permissions", children: true do
+
         context "user has edit rights on object" do
           before { subject.can(:edit, resource) }
+
           context "and object can have children" do
             let(:resource) { FactoryGirl.build(:collection) }
             it { is_expected.to be_able_to(:add_children, resource) }
           end
+
           context "but object cannot have children" do
             let(:resource) { FactoryGirl.build(:component) }
             it { is_expected.not_to be_able_to(:add_children, resource) }
           end
         end
+
         context "user lacks edit rights on attached_to object" do
           let(:resource) { FactoryGirl.build(:collection) }
           before { subject.cannot(:edit, resource) }

--- a/spec/support/shared_examples_for_events.rb
+++ b/spec/support/shared_examples_for_events.rb
@@ -165,7 +165,9 @@ RSpec.shared_examples "an event" do
 
   describe "rendering who/what performed the action" do
     context "when performed by a user" do
-      before { subject.user = User.new(username: "bob") }
+      before do
+        subject.user_key = "bob"
+      end
       it "should render the user" do
         expect(subject.performed_by).to eq "bob"
       end


### PR DESCRIPTION
To update the events table after running the migration, run this code:

```ruby
Ddr::Events::Event.joins(:user).includes(:user).find_each do |e|
  e.user_key = e.user.user_key
end
```

After the data update the assoiciation should removed on the user_id
column dropped from the events table.