### PR TITLE
Implements a custom failure app for Warden 

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -238,6 +238,7 @@ Devise.setup do |config|
   # end
 
   config.warden do |manager|
+    manager.failure_app = Ddr::Auth::FailureApp
     # :superuser scope
     manager.serialize_into_session(:superuser) { |superuser| superuser.id }
     manager.serialize_from_session(:superuser) { |id| Devise.mappings[:user].to.find(id) }

--- a/lib/ddr/auth.rb
+++ b/lib/ddr/auth.rb
@@ -8,6 +8,7 @@ module Ddr
     autoload :GroupService
     autoload :GrouperService
     autoload :RemoteGroupService
+    autoload :FailureApp
 
     # Group authorized to act as superuser
     mattr_accessor :superuser_group
@@ -44,6 +45,11 @@ module Ddr
     # Group of authenticated users
     mattr_accessor :authenticated_users_group do
       "registered"
+    end
+
+    # Whether to require Shibboleth authentication 
+    mattr_accessor :require_shib_user_authn do
+      false
     end
 
   end

--- a/lib/ddr/auth/failure_app.rb
+++ b/lib/ddr/auth/failure_app.rb
@@ -1,0 +1,16 @@
+module Ddr
+  module Auth
+    class FailureApp < Devise::FailureApp
+
+      def respond
+        if scope == :user && Ddr::Auth.require_shib_user_authn
+          store_location!
+          redirect_to user_omniauth_authorize_path(:shibboleth)
+        else
+          super
+        end
+      end
+
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    before_action :authenticate_user!
+    def index; end
+  end
+  describe "authentication failure handling" do
+    describe "when shibboleth user authentication is required" do
+      before { allow(Ddr::Auth).to receive(:require_shib_user_authn) { true } }
+      it "should redirect to the shib authn path" do
+        get :index
+        expect(response).to redirect_to(user_omniauth_authorize_path(:shibboleth))
+      end
+    end
+    describe "when shibboleth user authentication is not required" do
+      before { allow(Ddr::Auth).to receive(:require_shib_user_authn) { false } }
+      it "should redirect to the new user session path" do
+        get :index
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/routing/user_routing_spec.rb
+++ b/spec/routing/user_routing_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe "users router", type: :routing do
+  it "should have a new session route" do
+    expect(get: '/users/sign_in').to route_to(controller: 'users/sessions', action: 'new')
+  end
+  it "should have a new session path helper" do
+    expect(get: new_user_session_path).to route_to(controller: 'users/sessions', action: 'new')
+  end
+  it "should have a destroy session route" do
+    expect(get: '/users/sign_out').to route_to(controller: 'users/sessions', action: 'destroy')
+  end
+  it "should have a destroy session path helper" do
+    expect(get: destroy_user_session_path).to route_to(controller: 'users/sessions', action: 'destroy')
+  end
+  it "should have a shibboleth authentication path" do
+    expect(get: '/users/auth/shibboleth').to route_to(controller: 'users/omniauth_callbacks', action: 'passthru', provider: 'shibboleth')
+  end
+  it "should have a shibboleth authentication path helper" do
+    expect(get: user_omniauth_authorize_path(:shibboleth)).to route_to(controller: 'users/omniauth_callbacks', action: 'passthru', provider: 'shibboleth')
+  end
+  describe "redirects", type: :request do
+    it "should have a signed out path" do
+      get '/users/signed_out'
+      expect(response).to redirect_to('/')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -100,6 +100,8 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
+  config.include Devise::TestHelpers, type: :controller
+
   config.before(:suite) do
     DatabaseCleaner.clean
     ActiveFedora::Base.destroy_all


### PR DESCRIPTION
Replaces default Devise failure app.
Adds a configuration setting `Ddr::Auth.require_shib_user_authn` (default: `false`)
to force authentication failure response (via the failure app) to redirect to shib login instead of
default login form.
Closes #106

Upgrade notes:

- Set `Ddr::Auth.require_shib_user_authn = true` in production evnironment where
  desired to require Shib authentication.