### PR TITLE
Remove the failure app alert from the flash when shib authn is required

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,7 @@ class Users::SessionsController < Devise::SessionsController
 
   def new
     if Ddr::Auth.require_shib_user_authn
+      flash.discard(:alert)
       redirect_to user_omniauth_authorize_path(:shibboleth, origin: request.referrer)
     else
       store_location_for(:user, request.referrer)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Users::SessionsController, type: :controller do
         get :new
         expect(response).to redirect_to(user_omniauth_authorize_path(:shibboleth, origin: "/foo/bar"))
       end
+      it "should discard the flash alert" do
+        expect_any_instance_of(ActionDispatch::Flash::FlashHash).to receive(:discard).with(:alert)
+        get :new
+      end
     end
 
     describe "when shibboleth user authentication is NOT required" do
@@ -18,6 +22,10 @@ RSpec.describe Users::SessionsController, type: :controller do
         expect(subject).to receive(:store_location_for).with(:user, "/foo/bar")
         get :new
         expect(response).to render_template(:new)
+      end
+      it "should NOT discard the flash alert" do
+        expect_any_instance_of(ActionDispatch::Flash::FlashHash).not_to receive(:discard).with(:alert)
+        get :new
       end
     end
   end


### PR DESCRIPTION
Reason: The flash is displayed after the user authns to shib and returns
to the app, at which point the message is irrelevant ("sign in or sign up")
and confusing.