### PR TITLE
Assign default structural metadata; closes #134

### DIFF
--- a/lib/ddr/models/has_content.rb
+++ b/lib/ddr/models/has_content.rb
@@ -5,6 +5,16 @@ module Ddr
     module HasContent
       extend ActiveSupport::Concern
 
+      MASTER_FILE_TYPES = [ "image/tiff" ]
+
+      def master_file?
+        if respond_to?(:file_use) && file_use.present?
+          file_use == Ddr::Models::HasStructMetadata::FILE_USE_MASTER
+        else
+          MASTER_FILE_TYPES.include?(content_type)
+        end
+      end
+
       included do
         has_file_datastream name: Ddr::Datastreams::CONTENT,
                             versionable: true, 

--- a/lib/ddr/models/has_struct_metadata.rb
+++ b/lib/ddr/models/has_struct_metadata.rb
@@ -3,6 +3,9 @@ module Ddr
     module HasStructMetadata
       extend ActiveSupport::Concern
 
+      FILE_USE_MASTER = 'master'
+      FILE_USE_REFERENCE = 'reference'
+
       included do
         has_metadata "structMetadata",
                      type: Ddr::Datastreams::StructMetadataDatastream,
@@ -11,6 +14,42 @@ module Ddr
 
         has_attributes :file_group, :file_use, :order,
                        datastream: "structMetadata", multiple: false
+
+        after_create :assign_struct_metadata!
+      end
+
+      def assign_struct_metadata!
+        self.file_use = default_file_use if file_use.blank?
+        self.order = default_order if order.nil?
+        self.file_group = default_file_group if file_group.blank?
+        save! if changed?
+      end
+
+      private
+
+      def default_file_use
+        if has_content?
+          master_file? ? FILE_USE_MASTER : FILE_USE_REFERENCE
+        end
+      end
+
+      def default_order
+        siblings.size + 1
+      end
+
+      def default_file_group
+        identifier.first if has_content?
+      end
+
+      def siblings
+        if respond_to?(:parent) && parent.present?
+          if file_use && parent.respond_to?(:children_by_file_use)
+            sibs = parent.children_by_file_use[file_use]
+          else
+            sibs = parent.children
+          end
+        end
+        sibs || []
       end
 
     end

--- a/spec/models/has_struct_metadata_spec.rb
+++ b/spec/models/has_struct_metadata_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Ddr
+  module Models
+    RSpec.describe HasStructMetadata, type: :model do
+
+      context "component" do
+        describe "component creation" do
+          let(:item) { Item.new }
+          let(:comp) { Component.new(identifier: [ "id001" ]) }
+          before do
+            allow(comp).to receive(:parent).and_return(item)
+            allow(comp).to receive(:has_content?).and_return(true)
+            allow(comp).to receive(:content_type).and_return("image/tiff")
+            allow(item).to receive(:children_by_file_use).and_return({})
+          end
+          it "should assign default values for unassigned attributes" do
+            comp.save
+            expect(comp.file_use).to_not be_nil
+            expect(comp.order).to_not be_nil
+            expect(comp.file_group).to_not be_nil
+          end
+          it "should not overwrite assigned attributes" do
+            comp.update_attributes(file_use: 'foo', order: 3, file_group: 'special')
+            expect(comp.file_use).to eq('foo')
+            expect(comp.order).to eq(3)
+            expect(comp.file_group).to eq('special')
+          end
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Uses an after_create callback to assign default values (as appropriate) for any structural metadata
attributes that do not have values assigned as part of the initial creation process.