### PR TITLE
Hotfix: upgraded ezid-client to ~> 1.0

### DIFF
--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise", "~> 3.4"
   s.add_dependency "omniauth-shibboleth", "~> 1.2.0"
   s.add_dependency "grouper-rest-client"
-  s.add_dependency "ezid-client", "~> 0.9"
+  s.add_dependency "ezid-client", "~> 1.0"
   s.add_dependency "resque", "~> 1.25"
   s.add_dependency "rdf-vocab", "~> 0.4"
 


### PR DESCRIPTION
Version number has **not** been changed in the hotfix branch.