### PR TITLE
Adds DeletionEvent - closes #103

### DIFF
--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -13,3 +13,6 @@ ActiveSupport::Notifications.subscribe(Ddr::Notifications::CREATION, Ddr::Events
 
 # Update
 ActiveSupport::Notifications.subscribe(Ddr::Notifications::UPDATE, Ddr::Events::UpdateEvent)
+
+# Deletion
+ActiveSupport::Notifications.subscribe(Ddr::Notifications::DELETION, Ddr::Events::DeletionEvent)

--- a/lib/ddr/events.rb
+++ b/lib/ddr/events.rb
@@ -4,6 +4,7 @@ module Ddr
 
     autoload :Event
     autoload :CreationEvent
+    autoload :DeletionEvent
     autoload :FixityCheckEvent
     autoload :IngestionEvent
     autoload :UpdateEvent

--- a/lib/ddr/events/deletion_event.rb
+++ b/lib/ddr/events/deletion_event.rb
@@ -1,0 +1,12 @@
+module Ddr
+  module Events
+    class DeletionEvent < Event 
+
+      include PreservationEventBehavior
+
+      self.description = "Object deleted"
+      self.preservation_event_type = :del
+
+    end
+  end
+end

--- a/lib/ddr/events/event.rb
+++ b/lib/ddr/events/event.rb
@@ -34,7 +34,6 @@ module Ddr
   
       validates_presence_of :event_date_time, :pid
       validates :outcome, inclusion: {in: OUTCOMES, message: "\"%{value}\" is not a valid event outcome"}
-      validate :object_exists # unless/until we have a deaccession-type of event
  
       after_initialize :set_defaults
       before_save { failure! if exception.present? }
@@ -126,13 +125,6 @@ module Ddr
         event_date_time.utc.strftime DATE_TIME_FORMAT
       end
 
-      # Return boolean indicator of object existence
-      def object_exists?
-        !object.nil?
-      rescue ActiveFedora::ObjectNotFoundError => e
-        false
-      end
-
       protected
 
       def set_defaults
@@ -145,13 +137,6 @@ module Ddr
           software: default_software,
           outcome: default_outcome
         }
-      end
-
-      # Validation method
-      def object_exists
-        unless object_exists?
-          errors.add(:pid, "Object \"#{pid}\" does not exist in the repository") 
-        end
       end
 
       def default_software

--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -15,6 +15,10 @@ module Ddr
       include Hydra::Validations
       include HasAdminMetadata
 
+      after_destroy do
+        notify_event :deletion
+      end
+
       def copy_admin_policy_or_permissions_from(other)
         copy_permissions_from(other) unless copy_admin_policy_from(other)
       end

--- a/lib/ddr/notifications.rb
+++ b/lib/ddr/notifications.rb
@@ -5,6 +5,7 @@ module Ddr
     VIRUS_CHECK = "virus_check.events.ddr"
     CREATION = "creation.events.ddr"
     UPDATE = "update.events.ddr"
+    DELETION = "deletion.events.ddr"
 
     def self.notify_event(type, args={})
       name = "#{type}.events.ddr"

--- a/spec/models/events_spec.rb
+++ b/spec/models/events_spec.rb
@@ -60,5 +60,13 @@ module Ddr
         expect(subject.display_type).to eq "Validation"
       end
     end
+
+    RSpec.describe DeletionEvent, type: :model, events: true do
+      it_behaves_like "an event"
+      it_behaves_like "a preservation-related event"
+      it "should have a display type" do
+        expect(subject.display_type).to eq "Deletion"
+      end
+    end
   end
 end

--- a/spec/support/shared_examples_for_ddr_models.rb
+++ b/spec/support/shared_examples_for_ddr_models.rb
@@ -1,7 +1,18 @@
 RSpec.shared_examples "a DDR model" do
+
   it_behaves_like "a describable object"
   it_behaves_like "a governable object"
   it_behaves_like "an access controllable object"
   it_behaves_like "an object that has properties"
   it_behaves_like "an object that has a display title"
+
+  describe "events" do
+    describe "on deletion with #destroy" do
+      before { subject.save(validate: false) }
+      it "should create a deletion event" do
+        expect { subject.destroy }.to change { Ddr::Events::DeletionEvent.for_object(subject).count }.from(0).to(1)
+      end
+    end
+  end
+
 end

--- a/spec/support/shared_examples_for_event_loggables.rb
+++ b/spec/support/shared_examples_for_event_loggables.rb
@@ -1,3 +1,0 @@
-shared_examples "an event loggable object" do
-
-end

--- a/spec/support/shared_examples_for_events.rb
+++ b/spec/support/shared_examples_for_events.rb
@@ -31,27 +31,12 @@ end
 
 RSpec.shared_examples "an event" do
   describe "validation" do
-    context "of pid" do
-      it "should require presence" do
-        expect(subject).not_to be_valid
-        expect(subject.errors[:pid]).to include "can't be blank"
-      end
-      context "when the object exists" do
-        before { subject.pid = ActiveFedora::Base.create.pid }
-        it "should be valid" do
-          expect(subject).to be_valid
-        end
-      end
-      context "when the object doesn't exist" do
-        before { subject.pid = "test:123" }
-        it "should not be valid" do
-          expect(subject).not_to be_valid
-          expect(subject.errors).to have_key :pid
-        end
-      end
+    it "should require a PID" do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:pid]).to include "can't be blank"
     end
     it "should require an event_date_time" do
-      subject.event_date_time = nil # reset b/c set to default after init
+      allow(subject).to receive(:event_date_time) { nil } # b/c set to default after init
       expect(subject).not_to be_valid
       expect(subject.errors[:event_date_time]).to include "can't be blank"
     end
@@ -132,27 +117,6 @@ RSpec.shared_examples "an event" do
     it "should raise an ArgumentError if object is a new record" do
       allow(object).to receive(:new_record?) { true }
       expect { subject.object = object }.to raise_error ArgumentError
-    end
-  end
-
-  describe "object existence" do
-    it "should be false if pid is nil" do
-      expect(subject.object_exists?).to be_falsey
-    end
-    it "should be false if pid not found in repository" do
-      subject.pid = "test:123"
-      expect(subject.object_exists?).to be_falsey
-    end
-    it "should be true if object exists in repository" do
-      allow(ActiveFedora::Base).to receive(:find).with("test:123") { mock_object }
-      subject.pid = "test:123"
-      expect(subject.object_exists?).to be_truthy
-    end
-    it "should be true if object instance variable is set" do
-      obj = mock_object(pid: "test:123")
-      allow(obj).to receive(:new_record?) { false }
-      subject.object = obj
-      expect(subject.object_exists?).to be_truthy
     end
   end
 


### PR DESCRIPTION
Notes:
- Due to implementation of callbacks in ActiveFedora, a DeletionEvent
  is only created after #destroy, not #delete. We may want to consider
  patching #delete to ensure that a DeletionEvent is always logged.
- The validation of object existence has been removed from Ddr::Events::Event.
  Although the validation made some sense of events other than deletion,
  in practice, since event PIDs are not user-entered, it simply added
  a repository object load.