### PR TITLE
Ddr::Models::HasChildren#first_child returns nil if object has no children

### DIFF
--- a/lib/ddr/models/has_children.rb
+++ b/lib/ddr/models/has_children.rb
@@ -1,19 +1,15 @@
 module Ddr
   module Models
     module HasChildren
-      extend ActiveSupport::Concern
 
       def first_child
         if datastreams.include?(Ddr::Datastreams::CONTENT_METADATA) && datastreams[Ddr::Datastreams::CONTENT_METADATA].has_content?
+          # DEPRECATED
           first_child_pid = datastreams[Ddr::Datastreams::CONTENT_METADATA].first_pid
+          first_child_pid ? ActiveFedora::Base.find(first_child_pid) : nil
         else
-          first_child_pid = ActiveFedora::SolrService.query(association_query(:children), rows: 1, sort: "#{Ddr::IndexFields::IDENTIFIER} ASC").first["id"]
+          ActiveFedora::Base.where(association_query(:children)).order("#{Ddr::IndexFields::IDENTIFIER} ASC").first
         end      
-        begin
-          ActiveFedora::Base.find(first_child_pid, :cast => true) if first_child_pid
-        rescue ActiveFedora::ObjectNotFound
-          nil
-        end
       end
 
     end

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "1.11.8"
+    VERSION = "1.11.9"
   end
 end

--- a/spec/models/has_children_spec.rb
+++ b/spec/models/has_children_spec.rb
@@ -1,0 +1,31 @@
+module Ddr::Models
+  RSpec.describe HasChildren do 
+
+    subject { FactoryGirl.create(:collection) }
+
+    describe "#first_child" do
+      describe "when the object has no children" do
+        it "should return nil" do
+          expect(subject.first_child).to be_nil
+        end
+      end
+      describe "when the object has children" do
+        let(:child1) { FactoryGirl.create(:item) }
+        let(:child2) { FactoryGirl.create(:item) }
+        before do
+          child1.identifier = ["test002"]
+          child1.save
+          child2.identifier = ["test001"]
+          child2.save          
+          subject.children << child1
+          subject.children << child2
+          subject.save
+        end
+        it "should return the first child as sorted by identifiers" do
+          expect(subject.first_child).to eq(child2)
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Fixes #165
Also uses ActiveFedora query methods instead of SolrService and find.
The conditional branch which uses the deprecated contentMetadata
datastream is NOT tested, and was left in only for compatibility
with dul-hydra.