### PR TITLE
Refactor derivative generation; add PTIF derivative generation.

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -6,6 +6,7 @@
 class Component < Ddr::Models::Base
  
   include Ddr::Models::HasContent
+  include Ddr::Models::HasMultiresImage
   include Ddr::Models::HasStructMetadata
 
   belongs_to :parent, :property => :is_part_of, :class_name => 'Item'

--- a/lib/ddr/datastreams.rb
+++ b/lib/ddr/datastreams.rb
@@ -9,6 +9,7 @@ module Ddr
     DC = "DC"
     DEFAULT_RIGHTS = "defaultRights"
     DESC_METADATA = "descMetadata"
+    MULTIRES_IMAGE = "multiresImage"
     PROPERTIES = "properties"
     RELS_EXT = "RELS-EXT"
     RIGHTS_METADATA = "rightsMetadata"

--- a/lib/ddr/derivatives.rb
+++ b/lib/ddr/derivatives.rb
@@ -1,0 +1,26 @@
+module Ddr
+  module Derivatives
+    extend ActiveSupport::Autoload
+
+    autoload :Generator
+    autoload :PngGenerator
+    autoload :PtifGenerator
+
+    Derivative = Struct.new(:name, :datastream, :generator, :options)
+
+    # Eventually, we should inject the generator (probably) and the options (certainly) for each derivative
+    # (e.g., from configuration)
+    DERIVATIVES = { multires_image: 
+                        Derivative.new( :multires_image,
+                                        Ddr::Datastreams::MULTIRES_IMAGE,
+                                        Ddr::Derivatives::PtifGenerator,
+                                        "-define tiff:tile-geometry=256x256 -compress JPEG -quality 90"),
+                    thumbnail:
+                        Derivative.new( :thumbnail,
+                                        Ddr::Datastreams::THUMBNAIL,
+                                        Ddr::Derivatives::PngGenerator,
+                                        "-resize '100x100>'")
+                  }
+
+  end
+end

--- a/lib/ddr/derivatives/generator.rb
+++ b/lib/ddr/derivatives/generator.rb
@@ -1,0 +1,31 @@
+module Ddr
+  module Derivatives
+    # @abstract
+    class Generator
+
+      attr_reader :source, :output, :options
+
+      GeneratorResult = Struct.new(:stdout, :stderr, :status)
+
+      def initialize source, output, options=nil
+        raise ArgumentError, "Source must be a File or path to a file" unless Ddr::Utils.file_or_path?(source)
+        raise ArgumentError, "Output must be a File or path to a file" unless Ddr::Utils.file_or_path?(output)
+        @source = source
+        @output = output
+        @options = options
+      end
+
+      # The mime type of the output generated.
+      # Implemented in each subclass.
+      def self.output_mime_type
+        raise NotImplementedError
+      end
+
+      # The actions required to generate the output from the source.
+      # Implemented in each subclass.
+      def generate
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/ddr/derivatives/png_generator.rb
+++ b/lib/ddr/derivatives/png_generator.rb
@@ -1,0 +1,17 @@
+module Ddr
+  module Derivatives
+    class PngGenerator < Generator
+
+      def self.output_mime_type
+        "image/png"
+      end
+
+      def generate
+        command = "convert #{Ddr::Utils.file_path(source)} #{options} png:#{Ddr::Utils.file_path(output)}"
+        out, err, s = Open3.capture3(command)
+        GeneratorResult.new(out, err, s)
+      end
+
+    end
+  end
+end

--- a/lib/ddr/derivatives/ptif_generator.rb
+++ b/lib/ddr/derivatives/ptif_generator.rb
@@ -1,0 +1,17 @@
+module Ddr
+  module Derivatives
+    class PtifGenerator < Generator
+
+      def self.output_mime_type
+        "image/tiff"
+      end
+
+      def generate
+        command = "convert #{Ddr::Utils.file_path(source)} #{options} ptif:#{Ddr::Utils.file_path(output)}"
+        out, err, s = Open3.capture3(command)
+        GeneratorResult.new(out, err, s)
+      end
+
+    end
+  end
+end

--- a/lib/ddr/managers.rb
+++ b/lib/ddr/managers.rb
@@ -3,6 +3,7 @@ module Ddr
     extend ActiveSupport::Autoload
 
     autoload :Manager
+    autoload :DerivativesManager
     autoload :PermanentIdManager
     autoload :RoleManager
     autoload :WorkflowManager

--- a/lib/ddr/managers/derivatives_manager.rb
+++ b/lib/ddr/managers/derivatives_manager.rb
@@ -1,0 +1,119 @@
+require "resque"
+
+module Ddr
+  module Managers
+    class DerivativesManager < Manager
+
+      SCHEDULE_LATER = :later
+      SCHEDULE_NOW = :now
+      SCHEDULES = [ SCHEDULE_LATER, SCHEDULE_NOW ]
+
+      ACTION_DELETE = "delete"
+      ACTION_GENERATE = "generate"
+
+      def update_derivatives(schedule=SCHEDULE_LATER)
+        raise ArgumentError, "Must be one of #{SCHEDULES}" unless SCHEDULES.include?(schedule)
+        Ddr::Derivatives::DERIVATIVES.values.each do |derivative|
+          # Need to update derivative if object has a datastream for this type of derivative and
+          # either (or both) of the following conditions are true:
+          # - object already has content in the derivative's datastream (need to delete or replace it)
+          # - the derivative can be generated for this object
+          if object.datastreams.include?(derivative.datastream) &&
+                (object.datastreams[derivative.datastream].has_content? || generatable?(derivative))
+            schedule == SCHEDULE_NOW ? update_derivative(derivative) : Resque.enqueue(DerivativeJob, object.pid, derivative.name)
+          end
+        end
+      end
+
+      def update_derivative(derivative)
+        raise ArgumentError, "This object does not have a datastream for #{derivative.name} derivatives" unless
+                                  object.datastreams.include?(derivative.datastream)
+        if generatable? derivative
+          generate_derivative derivative
+        else
+          # Delete existing derivative (if there is one) if that type of derivative is no longer
+          # applicable to the object
+          if object.datastreams[derivative.datastream].has_content?
+            delete_derivative derivative
+          end
+        end
+      end
+
+      def generate_derivative(derivative)
+        ActiveSupport::Notifications.instrument(Ddr::Notifications::UPDATE,
+                                                pid: object.pid,
+                                                summary: "Generate #{derivative.name.to_s} derivative"
+                                                ) do |payload|
+          generate_derivative! derivative
+        end
+      end
+
+      def generate_derivative!(derivative)
+        Dir.mktmpdir do |tempdir|
+          generator_source = create_source_file(tempdir)
+          generator_output = File.new(File.join(tempdir, "output"), 'wb')
+          results = derivative.generator.new(generator_source.path, generator_output.path, derivative.options).generate
+          generator_source.close unless generator_source.closed?
+          if results.status.success?
+            generator_output = File.open(generator_output, 'rb')
+            object.reload if object.persisted?
+            object.add_file generator_output, derivative.datastream, mime_type: derivative.generator.output_mime_type
+            object.save!
+          else
+            Rails.logger.error results.stderr
+            raise Ddr::Models::DerivativeGenerationFailure,
+                    "Failure generating #{derivative.name} for #{object.pid}.  See Rails log file for more information."
+          end
+          generator_output.close unless generator_output.closed?
+        end
+      end
+
+      def delete_derivative(derivative)
+        ActiveSupport::Notifications.instrument(Ddr::Notifications::UPDATE,
+                                                pid: object.pid,
+                                                summary: "Delete derivative #{derivative.name.to_s}"
+                                                ) do |payload|
+          delete_derivative! derivative
+        end
+      end
+
+      def delete_derivative!(derivative)
+        File.unlink *object.datastreams[derivative.datastream].file_paths if
+                                                      object.datastreams[derivative.datastream].external?
+        object.datastreams[derivative.datastream].delete
+        object.save!
+      end
+
+      class DerivativeJob
+        @queue = :derivatives
+        def self.perform(pid, derivative_name)
+          object = ActiveFedora::Base.find(pid)
+          derivative = Ddr::Derivatives::DERIVATIVES[derivative_name.to_sym]
+          object.derivatives.update_derivative(derivative)
+        end
+      end
+
+      private
+
+      def create_source_file(dir)
+        generator_source = File.new(File.join(dir, "source"), "wb")
+        generator_source.write(object.content.content)
+        generator_source.close
+        generator_source
+      end
+
+      def generatable?(derivative)
+        return false unless object.has_content?
+        case derivative.name
+        when :multires_image
+          object.content_type == "image/tiff"
+        when :thumbnail
+          object.image? || object.pdf?
+        else
+          false
+        end
+      end
+
+    end
+  end
+end

--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -13,6 +13,7 @@ require 'hydra/validations'
 require 'ddr/actions'
 require 'ddr/auth'
 require 'ddr/datastreams'
+require 'ddr/derivatives'
 require 'ddr/events'
 require 'ddr/index_fields'
 require 'ddr/managers'
@@ -37,6 +38,7 @@ module Ddr
     autoload :HasAttachments
     autoload :HasChildren
     autoload :HasContent
+    autoload :HasMultiresImage
     autoload :HasProperties
     autoload :HasStructMetadata
     autoload :HasThumbnail
@@ -45,8 +47,11 @@ module Ddr
     autoload :Licensable
     autoload :SolrDocument
 
-    # Base directory of external file store
+    # Base directory of default external file store
     mattr_accessor :external_file_store
+
+    # Base directory of external file store for multires image derivatives
+    mattr_accessor :multires_image_external_file_store
 
     # Regexp for building external file subpath from hex digest
     mattr_accessor :external_file_subpath_regexp

--- a/lib/ddr/models/engine.rb
+++ b/lib/ddr/models/engine.rb
@@ -18,6 +18,7 @@ module Ddr
       #
       initializer "ddr_models.external_files" do
         Ddr::Models.external_file_store = ENV["EXTERNAL_FILE_STORE"]
+        Ddr::Models.multires_image_external_file_store = ENV["MULTIRES_IMAGE_EXTERNAL_FILE_STORE"]
         Ddr::Models.external_file_subpath_pattern = ENV["EXTERNAL_FILE_SUBPATH_PATTERN"] || "--"
       end
 

--- a/lib/ddr/models/error.rb
+++ b/lib/ddr/models/error.rb
@@ -2,8 +2,11 @@ module Ddr
   module Models
     # Base class for custom exceptions
     class Error < StandardError; end
-  
+
     # Invalid checksum
     class ChecksumInvalid < Error; end
+
+    # Derivative generation failure
+    class DerivativeGenerationFailure < Error; end
   end
 end

--- a/lib/ddr/models/has_multires_image.rb
+++ b/lib/ddr/models/has_multires_image.rb
@@ -1,0 +1,16 @@
+module Ddr
+  module Models
+    module HasMultiresImage
+      extend ActiveSupport::Concern
+  
+      included do
+        has_file_datastream name: Ddr::Datastreams::MULTIRES_IMAGE,
+                            label: "Multi-resolution image derivative for this object",
+                            control_group: 'E'
+
+        include FileManagement unless include?(FileManagement)
+      end
+
+    end
+  end
+end

--- a/lib/ddr/utils.rb
+++ b/lib/ddr/utils.rb
@@ -53,6 +53,13 @@ module Ddr::Utils
     URI.parse(uri).scheme == "file"
   end
 
+  def self.sanitize_filename file_name
+    return unless file_name
+    raise ArgumentError, "file_name argument must be a string" unless file_name.is_a?(String)
+    raise ArgumentError, "file_name argument must not include path" if file_name.include?(File::SEPARATOR)
+    file_name.gsub(/[^\w\.\-]/,"_")
+  end
+
   # Return file path for URI string 
   # Should reverse .path_to_uri
   # "file:/path/to/file" => "/path/to/file"

--- a/spec/managers/derivatives_manager_spec.rb
+++ b/spec/managers/derivatives_manager_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+module Ddr
+  module Managers
+    RSpec.describe DerivativesManager do
+
+      before(:all) do
+        class ContentBearing < ActiveFedora::Base
+          include Ddr::Models::HasAdminMetadata
+          include Ddr::Models::HasContent
+          include Ddr::Models::HasThumbnail
+          include Ddr::Models::EventLoggable
+          _save_callbacks.clear
+        end
+        class MultiresImageable < ContentBearing
+          include Ddr::Models::HasMultiresImage
+          _save_callbacks.clear
+        end
+      end
+
+      after(:all) do
+        Ddr::Managers.send(:remove_const, :MultiresImageable)
+        Ddr::Managers.send(:remove_const, :ContentBearing)
+      end
+
+      describe "generators called" do
+        before { object.add_file file, Ddr::Datastreams::CONTENT }
+        context "not multires_image_able" do
+          let(:object) { ContentBearing.new }
+          context "content is image" do
+            let(:file) { fixture_file_upload("image1.tiff", "image/tiff") }
+            it "should generate a thumbnail and not a ptif" do
+              expect(object.derivatives).to receive(:generate_derivative!).with(Ddr::Derivatives::DERIVATIVES[:thumbnail])
+              expect(object.derivatives).to_not receive(:generate_derivative!).with(Ddr::Derivatives::DERIVATIVES[:multires_image])
+              object.derivatives.update_derivatives(:now)
+            end
+          end
+          context "content is a PDF" do
+            let(:file) { fixture_file_upload("sample.pdf", "application/pdf") }
+            it "should generate a thumbnail and not a ptif" do
+              expect(object.derivatives).to receive(:generate_derivative!).with(Ddr::Derivatives::DERIVATIVES[:thumbnail])
+              expect(object.derivatives).to_not receive(:generate_derivative!).with(Ddr::Derivatives::DERIVATIVES[:multires_image])
+              object.derivatives.update_derivatives(:now)
+            end
+          end
+          context "content is neither an image nor a PDF" do
+            let(:file) { fixture_file_upload("sample.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") }
+            it "should generate neither a thumbnail nor a ptif" do
+              expect(object.derivatives).to_not receive(:generate_derivative!).with(Ddr::Derivatives::DERIVATIVES[:thumbnail])
+              expect(object.derivatives).to_not receive(:generate_derivative!).with(Ddr::Derivatives::DERIVATIVES[:multires_image])
+              object.derivatives.update_derivatives(:now)
+            end
+          end
+        end
+        context "multires_image_able" do
+          let(:object) { MultiresImageable.new }
+          context "content is tiff image" do
+            let(:file) { fixture_file_upload("image1.tiff", "image/tiff") }
+            it "should generate a thumbnail and a ptif" do
+              expect(object.derivatives).to receive(:generate_derivative!).with(Ddr::Derivatives::DERIVATIVES[:thumbnail])
+              expect(object.derivatives).to receive(:generate_derivative!).with(Ddr::Derivatives::DERIVATIVES[:multires_image])
+              object.derivatives.update_derivatives(:now)
+            end
+          end
+          context "content is not tiff image" do
+            let(:file) { fixture_file_upload("sample.pdf", "application/pdf") }
+            it "should generate a thumbnail but not a ptif" do
+              expect(object.derivatives).to receive(:generate_derivative!).with(Ddr::Derivatives::DERIVATIVES[:thumbnail])
+              expect(object.derivatives).to_not receive(:generate_derivative!).with(Ddr::Derivatives::DERIVATIVES[:multires_image])
+              object.derivatives.update_derivatives(:now)
+            end
+          end
+        end
+      end
+
+      describe "derivative generation" do
+        let(:file) { fixture_file_upload("image1.tiff", "image/tiff") }
+        before { object.upload! file }
+        describe "thumbnail" do
+          let(:object) { ContentBearing.create }
+          it "should create content in the thumbnail datastream" do
+            expect(object.datastreams[Ddr::Datastreams::THUMBNAIL]).to_not be_present
+            object.derivatives.generate_derivative! Ddr::Derivatives::DERIVATIVES[:thumbnail]
+            expect(object.datastreams[Ddr::Datastreams::THUMBNAIL]).to be_present
+          end
+        end
+        describe "ptif" do
+          let(:object) { MultiresImageable.create }
+          it "should create content in the multires image datastream" do
+            expect(object.datastreams[Ddr::Datastreams::MULTIRES_IMAGE]).to_not be_present
+            object.derivatives.generate_derivative! Ddr::Derivatives::DERIVATIVES[:multires_image]
+            expect(object.datastreams[Ddr::Datastreams::MULTIRES_IMAGE]).to be_present
+          end
+        end
+      end
+
+      describe "event creation" do
+        let(:file) { fixture_file_upload("image1.tiff", "image/tiff") }
+        before { object.upload! file }
+        let(:object) { MultiresImageable.create }
+        it "should create an update event for each derivative updated" do
+          expect {object.derivatives.update_derivatives(:now) }.to change { object.update_events.count }.by(2)
+        end
+      end
+
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,6 +112,7 @@ RSpec.configure do |config|
     ActiveFedora::Base.destroy_all
     Ddr::Models.configure do |config|
       config.external_file_store = Dir.mktmpdir
+      config.multires_image_external_file_store = Dir.mktmpdir
       config.external_file_subpath_pattern = "--"
     end
   end
@@ -119,6 +120,9 @@ RSpec.configure do |config|
   config.after(:suite) do
     if Ddr::Models.external_file_store && Dir.exist?(Ddr::Models.external_file_store)
       FileUtils.remove_entry_secure(Ddr::Models.external_file_store) 
+    end
+    if Ddr::Models.multires_image_external_file_store && Dir.exist?(Ddr::Models.multires_image_external_file_store)
+      FileUtils.remove_entry_secure(Ddr::Models.multires_image_external_file_store)
     end
   end
 

--- a/spec/support/shared_examples_for_has_content.rb
+++ b/spec/support/shared_examples_for_has_content.rb
@@ -30,7 +30,7 @@ RSpec.shared_examples "an object that can have content" do
         expect(object.content_type).to eq("image/tiff")
       end
       it "should create a 'virus check' event for the object" do
-        expect { object.save }.to change { object.virus_checks.count }.by(1)
+        expect { object.save }.to change { object.virus_checks.count }
       end
     end
     context "with option `:original_name=>false`" do
@@ -53,57 +53,19 @@ RSpec.shared_examples "an object that can have content" do
 
       context "and it's a new object" do
         before { object.add_file file, "content" }
-
-        context "and the content is an image" do
-          let(:file) { fixture_file_upload("library-devil.tiff", "image/tiff") }
-          it "should generate a thumbnail" do
-            expect(object.thumbnail).not_to be_present
-            object.save
-            expect(object.thumbnail).to be_present
-          end
-        end
-        context "and the content is a pdf" do
-          let(:file) { fixture_file_upload("sample.pdf", "application/pdf") }
-          it "should generate a thumbnail" do
-            expect(object.thumbnail).not_to be_present
-            object.save
-            expect(object.thumbnail).to be_present
-          end
-        end
-        context "and the content is neither an image nor a pdf" do
-          let(:file) { fixture_file_upload("sample.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") }
-          it "should not generate a thumbnail" do
-            expect(object.thumbnail).not_to be_present
-            object.save
-            expect(object.thumbnail).not_to be_present
-          end
+        let(:file) { fixture_file_upload("library-devil.tiff", "image/tiff") }
+        it "should generate derivatives" do
+          expect(object.derivatives).to receive(:update_derivatives)
+          object.save
         end
       end
 
       context "and it's an existing object with content" do
         before { object.upload! fixture_file_upload('library-devil.tiff', 'image/tiff') }
-
-        context "and the content is an image" do
-          let(:file) { fixture_file_upload("image1.tiff", "image/tiff") }
-          it "should generate a new thumbnail" do
-            expect(object.thumbnail).to be_present
-            expect { object.upload! file }.to change { object.thumbnail.content }
-          end
-        end
-        context "and the content is a pdf" do
-          let(:file) { fixture_file_upload("sample.pdf", "application/pdf") }
-          it "should generate a new thumbnail" do
-            expect(object.thumbnail).to be_present
-            expect { object.upload! file }.to change { object.thumbnail.content }
-          end
-        end
-        context "and the content is neither an image nor a pdf" do
-          let(:file) { fixture_file_upload("sample.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") }
-          it "should delete the thumbnail" do
-            expect(object.thumbnail).to be_present
-            object.upload! file
-            expect(object.thumbnail).to_not be_present
-          end
+        let(:file) { fixture_file_upload("image1.tiff", "image/tiff") }
+        it "should generate derivatives" do
+          expect(object.derivatives).to receive(:update_derivatives)
+          object.upload! file
         end
       end
     end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+module Ddr
+  RSpec.describe Utils do
+    describe "sanitize filename" do
+      it "should return nil if not given an argument" do
+        expect(Ddr::Utils.sanitize_filename(nil)).to be_nil
+      end
+      it "should raise an exception if given a non-String argument" do
+        expect { Ddr::Utils.sanitize_filename(File.new) }.to raise_error(ArgumentError)
+      end
+      it "should raise an exception if given a string with a path separator" do
+        expect { Ddr::Utils.sanitize_filename(File.join('my', 'file.txt')) }.to raise_error(ArgumentError)
+      end
+      it "should return the unaltered file name if given a sanitary file name" do
+        expect(Ddr::Utils.sanitize_filename(File.join('my-file01.txt'))).to eq('my-file01.txt')
+      end
+      it "should a sanitized file name if given an unsanitary file name" do
+        expect(Ddr::Utils.sanitize_filename(File.join('my##file01$.txt%%'))).to eq('my__file01_.txt__')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a DerivativesManager to manage creation, change, and deletion of
various derivatives based on the 'content' datastream.  By default
derivatives are generated asynchronously, with a separate Resque job for
each derivative to be generated.
Adds a 'multiresImage' datastream to hold PTIF's, JPEG2000's, or other
multi-resolution images for presentation by an image server.
Closes #170.