### PR TITLE
Adds `#permanent_id` method to SolrDocument

### DIFF
--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 3.1"
+  s.add_development_dependency "rspec-its"
   s.add_development_dependency "factory_girl_rails", "~> 4.4"
   s.add_development_dependency "jettywrapper", "~> 1.8"
   s.add_development_dependency "database_cleaner"

--- a/lib/ddr/models/solr_document.rb
+++ b/lib/ddr/models/solr_document.rb
@@ -158,6 +158,10 @@ module Ddr
         active_fedora_model.tableize
       end
 
+      def permanent_id
+        get(Ddr::IndexFields::PERMANENT_ID)
+      end
+
       private
 
       def targets_query

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe SolrDocument do
+
+  describe "#permanent_id" do
+    before { subject[Ddr::IndexFields::PERMANENT_ID] = "foo" }
+    its(:permanent_id) { is_expected.to eq("foo") }
+  end
+
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "ddr-models"
 require "rails"
 require "rspec/rails"
+require "rspec/its"
 require "factory_girl_rails"
 require "database_cleaner"
 require "tempfile"


### PR DESCRIPTION
This is a hotfix in support of https://github.com/duke-libraries/ddr-public/issues/102