### PR TITLE
Readds access to the legacy downloader role data for backward-compatibility

### DIFF
--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "grouper-rest-client"
   s.add_dependency "ezid-client", "~> 1.0"
   s.add_dependency "resque", "~> 1.25"
-  s.add_dependency "rdf-vocab", "~> 0.7"
+  s.add_dependency "rdf-vocab", "0.7.0"
   s.add_dependency "net-ldap", "~> 0.11"
 
   s.add_development_dependency "bundler", "~> 1.7"

--- a/lib/ddr/auth/group.rb
+++ b/lib/ddr/auth/group.rb
@@ -1,6 +1,7 @@
 module Ddr
   module Auth
     class Group < Agent
+
       configure type: RDF::FOAF.Group
 
       validates_format_of :name, with: /\A[\w.:\-]+\z/
@@ -9,6 +10,16 @@ module Ddr
       def has_member?(user)
         user.groups.include?(self)
       end
+
+      # Override for backward-compatibility with String-based groups
+      def method_missing(meth, *args)
+        if to_s.respond_to?(meth)
+          to_s.send(meth, *args)
+        else
+          super
+        end
+      end
+
     end
   end
 end

--- a/lib/ddr/managers/role_manager.rb
+++ b/lib/ddr/managers/role_manager.rb
@@ -3,6 +3,7 @@ module Ddr
     class RoleManager < Manager
 
       delegate :grant, :revoke, :granted?, :replace, :revoke_all, :where, to: :granted
+      delegate :downloader, to: :ds
 
       def granted
         @granted ||= Ddr::Auth::Roles::RoleSet.new(ds.access_role)

--- a/spec/auth/group_spec.rb
+++ b/spec/auth/group_spec.rb
@@ -16,5 +16,12 @@ module Ddr::Auth
       end
     end
 
+    describe "backward-compatible behavior" do
+      it "should delegate missing methods to the group name string" do
+        name = subject.to_s
+        expect(subject.sub("Group", "Apple")).to eq(name.sub("Group", "Apple"))
+      end
+    end
+
   end
 end

--- a/spec/managers/role_manager_spec.rb
+++ b/spec/managers/role_manager_spec.rb
@@ -3,7 +3,18 @@ module Ddr::Managers
 
     let(:obj) { FactoryGirl.build(:collection) }
 
-    subject { obj.roles }
+    subject { described_class.new(obj) }
+
+    describe "legacy roles" do
+      describe "#downloader" do
+        before do
+          obj.adminMetadata.downloader = "bob@example.com"
+        end
+        it "should return the downloader property of the adminMetadata datastream" do
+          expect(subject.downloader).to eq(["bob@example.com"])
+        end
+      end
+    end
 
     describe "granted roles" do
       it "should return the access roles defined on the datastream" do


### PR DESCRIPTION
Adds delegation of missing methods on Ddr::Auth::Group to the group
name as a string, also for backward-compatibility
Closes #203