### PR TITLE
Patches ActiveFedora 7 behaviors in order to prevent mis-casting of

### DIFF
--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -32,6 +32,7 @@ module Ddr
     autoload :Error
     autoload :ChecksumInvalid, 'ddr/models/error'
     autoload :DerivativeGenerationFailure, 'ddr/models/error'
+    autoload :ContentModelError, 'ddr/models/error'
     autoload :FixityCheckable
     autoload :Governable
     autoload :HasAdminMetadata

--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -33,6 +33,14 @@ module Ddr
         [self.class.to_s, pid].join(" ")
       end
 
+      # @override ActiveFedora::Core
+      # See ActiveFedora overrides in engine initializers
+      def adapt_to_cmodel
+        super
+      rescue ::TypeError
+        raise ContentModelError, "Cannot adapt to nil content model."
+      end
+
     end
   end
 end

--- a/lib/ddr/models/engine.rb
+++ b/lib/ddr/models/engine.rb
@@ -16,6 +16,32 @@ module Ddr
       #
       # Initializers
       #
+
+      initializer "active_fedora.content_model" do
+        ActiveFedora::ContentModel.module_eval do
+          # Returns the first known model for the object is equal to or a
+          # subclass of the object's class.
+          # This bubbles up, e.g., to prevent mis-casting via `.find`.
+          def self.best_model_for(obj)
+            known_models_for(obj).find { |model| model <= obj.class }
+          end
+        end
+      end
+
+      initializer "active_fedora.finder_methods" do
+        ActiveFedora::FinderMethods.module_eval do
+          # Override tries to cast by default
+          def load_from_fedora(pid, cast)
+            inner = ActiveFedora::DigitalObject.find(klass, pid)
+            obj = klass.allocate.init_with_object(inner)
+            if cast != false
+              obj = obj.adapt_to_cmodel
+            end
+            obj
+          end
+        end
+      end
+
       initializer "ddr_models.external_files" do
         Ddr::Models.external_file_store = ENV["EXTERNAL_FILE_STORE"]
         Ddr::Models.multires_image_external_file_store = ENV["MULTIRES_IMAGE_EXTERNAL_FILE_STORE"]

--- a/lib/ddr/models/error.rb
+++ b/lib/ddr/models/error.rb
@@ -8,5 +8,8 @@ module Ddr
 
     # Derivative generation failure
     class DerivativeGenerationFailure < Error; end
+
+    # Content model casting error
+    class ContentModelError < Error; end
   end
 end

--- a/spec/models/active_fedora_base_spec.rb
+++ b/spec/models/active_fedora_base_spec.rb
@@ -1,6 +1,31 @@
 require 'spec_helper'
 
 RSpec.describe ActiveFedora::Base do
+
+  describe ".find" do
+    let!(:collection) { FactoryGirl.create(:collection) }
+    describe "when called on the wrong class" do
+      it "should raise an exception" do
+        expect { Item.find(collection.pid) }.to raise_error(Ddr::Models::ContentModelError)
+      end
+    end
+    describe "when called on Ddr::Models::Base" do
+      it "should cast to the object's class" do
+        expect(Ddr::Models::Base.find(collection.pid)).to eq(collection)
+      end
+    end
+    describe "when called on ActiveFedora::Base" do
+      it "should cast to the object's class" do
+        expect(ActiveFedora::Base.find(collection.pid)).to eq(collection)
+      end
+    end
+    describe "when called on the object's class" do
+      it "should return the object" do
+        expect(Collection.find(collection.pid)).to eq(collection)
+      end
+    end
+  end
+
   describe "attachments", attachments: true do
     before do
       class AttachToable < ActiveFedora::Base
@@ -104,4 +129,5 @@ RSpec.describe ActiveFedora::Base do
       end
     end
   end
+
 end


### PR DESCRIPTION
objects by calling .find on the wrong class.