### PR TITLE
Adds datastream for extracted text

### DIFF
--- a/lib/ddr/datastreams.rb
+++ b/lib/ddr/datastreams.rb
@@ -9,6 +9,7 @@ module Ddr
     DC = "DC"
     DEFAULT_RIGHTS = "defaultRights"
     DESC_METADATA = "descMetadata"
+    EXTRACTED_TEXT = "extractedText"
     MULTIRES_IMAGE = "multiresImage"
     PROPERTIES = "properties"
     RELS_EXT = "RELS-EXT"
@@ -24,12 +25,13 @@ module Ddr
 
     CHECKSUM_TYPES = [ CHECKSUM_TYPE_MD5, CHECKSUM_TYPE_SHA1, CHECKSUM_TYPE_SHA256, CHECKSUM_TYPE_SHA384, CHECKSUM_TYPE_SHA512 ]
 
-    autoload :MetadataDatastream
     autoload :AdministrativeMetadataDatastream
+    autoload :DatastreamBehavior
     autoload :DescriptiveMetadataDatastream
+    autoload :MetadataDatastream
+    autoload :PlainTextDatastream
     autoload :PropertiesDatastream
     autoload :StructuralMetadataDatastream
-    autoload :DatastreamBehavior
 
   end
 end

--- a/lib/ddr/datastreams/plain_text_datastream.rb
+++ b/lib/ddr/datastreams/plain_text_datastream.rb
@@ -1,0 +1,9 @@
+module Ddr
+  module Datastreams
+    class PlainTextDatastream < ActiveFedora::Datastream
+      def self.default_attributes
+        super.merge(mimeType: "text/plain")
+      end
+    end
+  end
+end

--- a/lib/ddr/index_fields.rb
+++ b/lib/ddr/index_fields.rb
@@ -14,6 +14,7 @@ module Ddr
     DEFAULT_LICENSE_DESCRIPTION = solr_name :default_license_description, type: :string
     DEFAULT_LICENSE_TITLE       = solr_name :default_license_title, type: :string
     DEFAULT_LICENSE_URL         = solr_name :default_license_url, type: :string
+    EXTRACTED_TEXT              = solr_name :extracted_text, :searchable, type: :text
     FILE_GROUP                  = solr_name :struct_metadata__file_group, :stored_sortable
     FILE_USE                    = solr_name :struct_metadata__file_use, :stored_sortable
     HAS_MODEL                   = solr_name :has_model, :symbol

--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -41,6 +41,10 @@ module Ddr
         raise ContentModelError, "Cannot adapt to nil content model."
       end
 
+      def has_extracted_text?
+        false
+      end
+
     end
   end
 end

--- a/lib/ddr/models/has_content.rb
+++ b/lib/ddr/models/has_content.rb
@@ -16,10 +16,18 @@ module Ddr
       end
 
       included do
-        has_file_datastream name: Ddr::Datastreams::CONTENT,
-                            versionable: true, 
-                            label: "Content file for this object",
-                            control_group: "M"
+        has_file_datastream \
+          name: Ddr::Datastreams::CONTENT,
+          versionable: true,
+          label: "Content file for this object",
+          control_group: "M"
+
+        has_file_datastream \
+          name: Ddr::Datastreams::EXTRACTED_TEXT,
+          type: Ddr::Datastreams::PlainTextDatastream,
+          versionable: true,
+          label: "Text extracted from the content file",
+          control_group: "M"
 
         has_attributes :original_filename, datastream: "adminMetadata", multiple: false
 
@@ -89,6 +97,10 @@ module Ddr
 
       def content_changed?
         content.external? ? content.dsLocation_changed? : content.content_changed?
+      end
+
+      def has_extracted_text?
+        extractedText.has_content?
       end
 
       protected

--- a/lib/ddr/models/indexing.rb
+++ b/lib/ddr/models/indexing.rb
@@ -46,6 +46,9 @@ module Ddr
         if has_multires_image?
           fields[MULTIRES_IMAGE_FILE_PATH] = multires_image_file_path
         end
+        if has_extracted_text?
+          fields[EXTRACTED_TEXT] = extractedText.content
+        end
         if is_a? Component
           fields[COLLECTION_URI] = collection_uri
         end

--- a/spec/models/has_admin_metadata_spec.rb
+++ b/spec/models/has_admin_metadata_spec.rb
@@ -36,21 +36,7 @@ module Ddr
 
       describe "permanent id and permanent url" do
 
-        before(:all) do
-          class PermanentlyIdentifiable < ActiveFedora::Base
-            include Describable
-            include Indexing
-            include AccessControllable
-            include HasAdminMetadata
-            include EventLoggable
-          end
-        end
-
-        after(:all) do
-          Ddr::Models.send(:remove_const, :PermanentlyIdentifiable)
-        end
-
-        subject { PermanentlyIdentifiable.new }
+        subject { FactoryGirl.build(:item) }
 
         describe "permanent_id" do
           describe "when a permanent id has not been assigned" do
@@ -65,15 +51,15 @@ module Ddr
             context "and auto-assignment is enabled" do
               before { allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { true } }
               it "should assign a permanent id" do
-                expect_any_instance_of(PermanentlyIdentifiable).to receive(:assign_permanent_id!) { nil }
-                PermanentlyIdentifiable.create
+                expect(subject).to receive(:assign_permanent_id!) { nil }
+                subject.save!
               end
             end
             context "and auto-assignment is disabled" do
               before { allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { false } }
               it "should not assign a permanent id" do
-                expect_any_instance_of(PermanentlyIdentifiable).not_to receive(:assign_permanent_id!)
-                PermanentlyIdentifiable.create
+                expect(subject).not_to receive(:assign_permanent_id!)
+                subject.save!
               end
             end
           end        
@@ -82,16 +68,16 @@ module Ddr
               before { allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { true } }
               it "should assign a permanent id once" do
                 expect(subject).to receive(:assign_permanent_id!).once { nil }
-                subject.save
+                subject.save!
                 subject.title = ["New Title"]
-                subject.save
+                subject.save!
               end
             end
             context "and auto-assignment is disabled" do
               before { allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { false } }
               it "should not assign a permanent id" do
                 expect(subject).not_to receive(:assign_permanent_id!)
-                subject.save
+                subject.save!
               end
             end
           end
@@ -143,18 +129,8 @@ module Ddr
       end
 
       describe "workflow" do
-        before(:all) do
-          class Workflowable < ActiveFedora::Base
-            include AccessControllable
-            include HasAdminMetadata
-          end
-        end
 
-        after(:all) do
-          Ddr::Models.send(:remove_const, :Workflowable)
-        end
-
-        subject { Workflowable.new }
+        subject { FactoryGirl.build(:item) }
 
         describe "#published?" do
           context "object is published" do

--- a/spec/support/shared_examples_for_has_content.rb
+++ b/spec/support/shared_examples_for_has_content.rb
@@ -3,46 +3,62 @@ require 'openssl'
 
 RSpec.shared_examples "an object that can have content" do
 
-  let(:object) { described_class.new(title: [ "I Have Content!" ]) }
+  subject { described_class.new(title: [ "I Have Content!" ]) }
 
   it "should delegate :validate_checksum! to :content" do
     checksum = "dea56f15b309e47b74fa24797f85245dda0ca3d274644a96804438bbd659555a"
-    expect(object.content).to receive(:validate_checksum!).with(checksum, "SHA-256")
-    object.validate_checksum!(checksum, "SHA-256")
+    expect(subject.content).to receive(:validate_checksum!).with(checksum, "SHA-256")
+    subject.validate_checksum!(checksum, "SHA-256")
   end
 
   describe "indexing" do
     let(:file) { fixture_file_upload("library-devil.tiff", "image/tiff") }
-    before { object.upload file }
+    before { subject.upload file }
     it "should index the content ds control group" do
-      expect(object.to_solr).to include(Ddr::IndexFields::CONTENT_CONTROL_GROUP)
+      expect(subject.to_solr).to include(Ddr::IndexFields::CONTENT_CONTROL_GROUP)
+    end
+  end
+
+  describe "extracted text" do
+    describe "when it is not present" do
+      its(:has_extracted_text?) { is_expected.to be false }
+      it "should not be indexed" do
+        expect(subject.to_solr).not_to include(Ddr::IndexFields::EXTRACTED_TEXT)
+      end
+    end
+    describe "when it is present" do
+      before { subject.extractedText.content = "This is my text. See Spot run." }
+      its(:has_extracted_text?) { is_expected.to be true }
+      it "should be indexed" do
+        expect(subject.to_solr[Ddr::IndexFields::EXTRACTED_TEXT]).to eq("This is my text. See Spot run.")
+      end
     end
   end
 
   describe "adding a file" do
     let(:file) { fixture_file_upload("library-devil.tiff", "image/tiff") }
     context "defaults" do
-      before { object.add_file file, "content" }
+      before { subject.add_file file, "content" }
       it "should have an original_filename" do
-        expect(object.original_filename).to eq("library-devil.tiff")
+        expect(subject.original_filename).to eq("library-devil.tiff")
       end
       it "should have a content_type" do
-        expect(object.content_type).to eq("image/tiff")
+        expect(subject.content_type).to eq("image/tiff")
       end
       it "should create a 'virus check' event for the object" do
-        expect { object.save }.to change { object.virus_checks.count }
+        expect { subject.save }.to change { subject.virus_checks.count }
       end
     end
     context "with option `:original_name=>false`" do
-      before { object.add_file file, "content", original_name: false }
+      before { subject.add_file file, "content", original_name: false }
       it "should not have an original_filename" do
-        expect(object.original_filename).to be_nil
+        expect(subject.original_filename).to be_nil
       end
     end
     context "with `:original_name` option set to a string" do
-      before { object.add_file file, "content", original_name: "another-name.tiff" }
+      before { subject.add_file file, "content", original_name: "another-name.tiff" }
       it "should have an original_filename" do
-        expect(object.original_filename).to eq("another-name.tiff")
+        expect(subject.original_filename).to eq("another-name.tiff")
       end
     end
   end
@@ -52,20 +68,20 @@ RSpec.shared_examples "an object that can have content" do
     describe "when new content is present" do
 
       context "and it's a new object" do
-        before { object.add_file file, "content" }
+        before { subject.add_file file, "content" }
         let(:file) { fixture_file_upload("library-devil.tiff", "image/tiff") }
         it "should generate derivatives" do
-          expect(object.derivatives).to receive(:update_derivatives)
-          object.save
+          expect(subject.derivatives).to receive(:update_derivatives)
+          subject.save
         end
       end
 
       context "and it's an existing object with content" do
-        before { object.upload! fixture_file_upload('library-devil.tiff', 'image/tiff') }
+        before { subject.upload! fixture_file_upload('library-devil.tiff', 'image/tiff') }
         let(:file) { fixture_file_upload("image1.tiff", "image/tiff") }
         it "should generate derivatives" do
-          expect(object.derivatives).to receive(:update_derivatives)
-          object.upload! file
+          expect(subject.derivatives).to receive(:update_derivatives)
+          subject.upload! file
         end
       end
     end
@@ -74,17 +90,17 @@ RSpec.shared_examples "an object that can have content" do
   describe "#upload" do
     let(:file) { fixture_file_upload("library-devil.tiff", "image/tiff") }
     it "should add the file to the content datastream" do
-      expect(object).to receive(:add_file).with(file, "content", {})
-      object.upload(file)
+      expect(subject).to receive(:add_file).with(file, "content", {})
+      subject.upload(file)
     end
   end
 
   describe "#upload!" do 
     let(:file) { fixture_file_upload("library-devil.tiff", "image/tiff") }
     it "should add the file to the content datastream and save the object" do
-      expect(object).to receive(:add_file).with(file, "content", {}).and_call_original
-      expect(object).to receive(:save)
-      object.upload!(file)
+      expect(subject).to receive(:add_file).with(file, "content", {}).and_call_original
+      expect(subject).to receive(:save)
+      subject.upload!(file)
     end
   end
 


### PR DESCRIPTION
Closes #224
- Adds `Ddr::Datastreams::PlainTextDatastream` to set default mimeType to
"text/plain"
- Adds `#has_extracted_text?` method to `Ddr::Models::Base`.
- Adds unstored text index field (extracted_text_teim) for indexing extracted text.