### PR TITLE
Changes indexing strategy for identifiers.  Closes #257.

### DIFF
--- a/lib/ddr/index_fields.rb
+++ b/lib/ddr/index_fields.rb
@@ -21,7 +21,7 @@ module Ddr
     FILE_GROUP                  = solr_name :struct_metadata__file_group, :stored_sortable
     FILE_USE                    = solr_name :struct_metadata__file_use, :stored_sortable
     HAS_MODEL                   = solr_name :has_model, :symbol
-    IDENTIFIER                  = solr_name :identifier, :stored_sortable
+    IDENTIFIER_ALL              = solr_name :identifier_all, :symbol
     INTERNAL_URI                = solr_name :internal_uri, :stored_sortable
     IS_ATTACHED_TO              = solr_name :is_attached_to, :symbol
     IS_EXTERNAL_TARGET_FOR      = solr_name :is_external_target_for, :symbol

--- a/lib/ddr/models/describable.rb
+++ b/lib/ddr/models/describable.rb
@@ -72,7 +72,7 @@ module Ddr
 
     module ClassMethods
       def find_by_identifier(identifier)
-        find(Ddr::IndexFields::IDENTIFIER => identifier)
+        find(Ddr::IndexFields::IDENTIFIER_ALL => identifier)
       end
     end
 

--- a/lib/ddr/models/has_children.rb
+++ b/lib/ddr/models/has_children.rb
@@ -3,7 +3,7 @@ module Ddr
     module HasChildren
 
       def first_child
-        ActiveFedora::Base.where(association_query(:children)).order("#{Ddr::IndexFields::IDENTIFIER} ASC").first
+        ActiveFedora::Base.where(association_query(:children)).order("#{Ddr::IndexFields::LOCAL_ID} ASC").first
       end
 
     end

--- a/lib/ddr/models/indexing.rb
+++ b/lib/ddr/models/indexing.rb
@@ -13,7 +13,7 @@ module Ddr
         fields = {
           TITLE             => title_display,
           INTERNAL_URI      => internal_uri,
-          IDENTIFIER        => identifier_sort,
+          IDENTIFIER_ALL    => all_identifiers,
           WORKFLOW_STATE    => workflow_state,
           LOCAL_ID          => local_id,
           ADMIN_SET         => admin_set,
@@ -70,8 +70,8 @@ module Ddr
         "[#{pid}]"
       end
 
-      def identifier_sort
-        identifier.first
+      def all_identifiers
+        identifier + [local_id, permanent_id, pid].compact
       end
 
       def associated_collection

--- a/lib/ddr/utils.rb
+++ b/lib/ddr/utils.rb
@@ -93,7 +93,7 @@ module Ddr::Utils
     model = opts.fetch(:model, nil)
     collection = opts.fetch(:collection, nil)
     objs = []
-    ActiveFedora::Base.find_each( { Ddr::IndexFields::IDENTIFIER => identifier }, { :cast => true } ) { |o| objs << o }
+    ActiveFedora::Base.find_each( { Ddr::IndexFields::IDENTIFIER_ALL => identifier }, { :cast => true } ) { |o| objs << o }
     pids = []
     objs.each { |obj| pids << obj.pid }
     if model.present?

--- a/spec/models/has_children_spec.rb
+++ b/spec/models/has_children_spec.rb
@@ -13,15 +13,15 @@ module Ddr::Models
         let(:child1) { FactoryGirl.create(:item) }
         let(:child2) { FactoryGirl.create(:item) }
         before do
-          child1.identifier = ["test002"]
+          child1.local_id = "test002"
           child1.save
-          child2.identifier = ["test001"]
+          child2.local_id = "test001"
           child2.save
           subject.children << child1
           subject.children << child2
           subject.save
         end
-        it "should return the first child as sorted by identifiers" do
+        it "should return the first child as sorted by local ID" do
           expect(subject.first_child).to eq(child2)
         end
       end

--- a/spec/support/shared_examples_for_ddr_models.rb
+++ b/spec/support/shared_examples_for_ddr_models.rb
@@ -6,6 +6,7 @@ RSpec.shared_examples "a DDR model" do
   it_behaves_like "an access controllable object"
   it_behaves_like "an object that has properties"
   it_behaves_like "an object that has a display title"
+  it_behaves_like "an object that has identifiers"
 
   describe "events" do
     describe "on deletion with #destroy" do

--- a/spec/support/shared_examples_for_indexing.rb
+++ b/spec/support/shared_examples_for_indexing.rb
@@ -34,3 +34,26 @@ RSpec.shared_examples "an object that has a display title" do
     end
   end
 end
+
+RSpec.shared_examples "an object that has identifiers" do
+  describe "#all_identifiers" do
+    let(:object) { described_class.new(pid: 'test:3') }
+    subject { object.all_identifiers }
+    context "has descriptive identifiers, local ID, permanent ID, and PID" do
+      before do
+        object.identifier = [ 'ID001', 'ID002' ]
+        object.local_id = 'LOCAL_ID_A'
+        object.permanent_id = 'ark:/999999/cd3'
+      end
+      it "should return all the identifiers" do
+        expect(subject).to match_array([ 'ID001', 'ID002', 'LOCAL_ID_A', 'ark:/999999/cd3', 'test:3' ])
+      end
+    end
+    context "no descriptive identifiers or local ID" do
+      before { object.permanent_id = 'ark:/999999/cd3' }
+      it "should return the permanent ID and PID" do
+        expect(subject).to match_array([ 'ark:/999999/cd3', 'test:3' ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Removes Ddr::IndexFields::IDENTIFIER.
Adds Ddr::IndexFields::IDENTIFIER_ALL that includes dcterms:identifier, local_id, permanent_id, and pid.