### PR TITLE
Remove old structural metadata index fields and methods; closes #256

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,16 +20,4 @@ class Item < Ddr::Models::Base
   alias_method :collection_id, :parent_id
   alias_method :collection=, :parent=
 
-  def children_by_file_use
-    file_uses = {}
-    sort_key = "#{Ddr::IndexFields::FILE_USE} ASC, #{Ddr::IndexFields::ORDER} ASC"
-    results = ActiveFedora::SolrService.query(association_query(:children), rows: 999999, sort: sort_key)
-    objs = ActiveFedora::SolrService.lazy_reify_solr_results(results)
-    objs.each do |obj|
-      file_uses[obj.file_use] ||= []
-      file_uses[obj.file_use] << obj
-    end
-    file_uses
-  end
-
 end

--- a/lib/ddr/index_fields.rb
+++ b/lib/ddr/index_fields.rb
@@ -18,8 +18,6 @@ module Ddr
     DEFAULT_LICENSE_TITLE       = solr_name :default_license_title, type: :string
     DEFAULT_LICENSE_URL         = solr_name :default_license_url, type: :string
     EXTRACTED_TEXT              = solr_name :extracted_text, :searchable, type: :text
-    FILE_GROUP                  = solr_name :struct_metadata__file_group, :stored_sortable
-    FILE_USE                    = solr_name :struct_metadata__file_use, :stored_sortable
     HAS_MODEL                   = solr_name :has_model, :symbol
     IDENTIFIER_ALL              = solr_name :identifier_all, :symbol
     INTERNAL_URI                = solr_name :internal_uri, :stored_sortable
@@ -45,7 +43,6 @@ module Ddr
     OBJECT_STATE                = solr_name :object_state, :stored_sortable
     OBJECT_CREATE_DATE          = solr_name :system_create, :stored_sortable, type: :date
     OBJECT_MODIFIED_DATE        = solr_name :system_modified, :stored_sortable, type: :date
-    ORDER                       = solr_name :struct_metadata__order, :stored_sortable, type: :integer
     PERMANENT_ID                = solr_name :permanent_id, :stored_sortable, type: :string
     PERMANENT_URL               = solr_name :permanent_url, :stored_sortable, type: :string
     POLICY_ROLE                 = solr_name :policy_role, :facetable, type: :string

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,16 +5,4 @@ RSpec.describe Item, :type => :model do
   it_behaves_like "it has an association", :belongs_to, :parent, :is_member_of_collection, "Collection"
   it_behaves_like "it has an association", :has_many, :children, :is_part_of, "Component"
 
-  context "has structured children" do
-    let!(:item) { Item.create }
-    let!(:comp1) { Component.create(parent: item, file_use: 'master', order: 2) }
-    let!(:comp2) { Component.create(parent: item, file_use: 'reference', order: 1) }
-    let!(:comp3) { Component.create(parent: item, file_use: 'master', order: 1) }
-    it "should group and order the children" do
-      results = item.children_by_file_use
-      expect(results['master']).to eq([ comp3, comp1 ])
-      expect(results['reference']).to eq([ comp2 ])
-    end
-  end
-
 end


### PR DESCRIPTION
Removes FILE_GROUP, FILE_USE, and ORDER from Ddr::IndexFields.
Removes #children_by_file_use from Item.