### PR TITLE
Adds Ddr::Jobs::MigrateLegacyAuthorization job for authz migration.

### DIFF
--- a/lib/ddr/auth/legacy/legacy_authorization.rb
+++ b/lib/ddr/auth/legacy/legacy_authorization.rb
@@ -4,15 +4,40 @@ module Ddr::Auth
   class LegacyAuthorization < SimpleDelegator
 
     def to_roles
-      sources
-        .map { |auth| auth.new(self).to_roles }
-        .reduce(&:merge)
+      sources.map(&:to_roles).reduce(&:merge)
+    end
+
+    def clear
+      sources.each(&:clear)
+    end
+
+    def clear?
+      sources.all? { |auth| auth.source.empty? }
+    end
+
+    def migrate
+      migrated = inspect
+      roles.grant *to_roles
+      clear
+      ["LEGACY AUTHORIZATION DATA", migrated, "ROLES", roles.serialize.inspect].join("\n\n")
+    end
+
+    def inspect
+      sources.map { |auth| auth.inspect }.join("\n")
     end
 
     private
 
     def sources
-      [ LegacyPermissions, LegacyRoles, LegacyDefaultPermissions ]
+      wrappers.map { |wrapper| wrapper.new(self) }
+    end
+
+    def wrappers
+      classes = [ LegacyPermissions, LegacyRoles ]
+      if respond_to? :default_permissions
+        classes << LegacyDefaultPermissions
+      end
+      classes
     end
 
   end

--- a/lib/ddr/auth/legacy/legacy_default_permissions.rb
+++ b/lib/ddr/auth/legacy/legacy_default_permissions.rb
@@ -2,7 +2,7 @@ module Ddr::Auth
   class LegacyDefaultPermissions < AbstractLegacyPermissions
 
     def source
-      respond_to?(:default_permissions) ? default_permissions : []
+      default_permissions
     end
 
     def role_type(access)
@@ -18,6 +18,15 @@ module Ddr::Auth
 
     def scope
       Roles::POLICY_SCOPE
+    end
+
+    def clear
+      defaultRights.clear_permissions!
+      defaultRights.content = defaultRights.to_xml
+    end
+
+    def inspect
+      "DEFAULT PERMISSIONS: #{source.inspect}"
     end
 
   end

--- a/lib/ddr/auth/legacy/legacy_permissions.rb
+++ b/lib/ddr/auth/legacy/legacy_permissions.rb
@@ -20,5 +20,14 @@ module Ddr::Auth
       Roles::RESOURCE_SCOPE
     end
 
+    def clear
+      rightsMetadata.clear_permissions!
+      rightsMetadata.content = rightsMetadata.to_xml
+    end
+
+    def inspect
+      "PERMISSIONS: #{source.map(&:to_hash).inspect}"
+    end
+
   end
 end

--- a/lib/ddr/auth/legacy/legacy_roles.rb
+++ b/lib/ddr/auth/legacy/legacy_roles.rb
@@ -3,10 +3,22 @@ require "delegate"
 module Ddr::Auth
   class LegacyRoles < SimpleDelegator
 
+    def source
+      adminMetadata.downloader
+    end
+
     def to_roles
-      adminMetadata.downloader.each_with_object(Roles::DetachedRoleSet.new) do |agent, memo|
+      source.each_with_object(Roles::DetachedRoleSet.new) do |agent, memo|
         memo.grant Roles::Role.build(type: Roles::DOWNLOADER, agent: agent, scope: Roles::RESOURCE_SCOPE)
       end
+    end
+
+    def clear
+      source.clear
+    end
+
+    def inspect
+      "DOWNLOADER: #{source.inspect}"
     end
 
   end

--- a/lib/ddr/auth/roles/role_set.rb
+++ b/lib/ddr/auth/roles/role_set.rb
@@ -77,7 +77,7 @@ module Ddr::Auth
       end
 
       def ==(other)
-        if self.class == other.class
+        if other.is_a? RoleSet
           self.to_set == other.to_set
         else
           super

--- a/lib/ddr/jobs.rb
+++ b/lib/ddr/jobs.rb
@@ -3,6 +3,7 @@ module Ddr
     extend ActiveSupport::Autoload
 
     autoload :PermanentId
+    autoload :MigrateLegacyAuthorization
 
     autoload_at 'ddr/jobs/permanent_id' do
       autoload :MakeUnavailable

--- a/lib/ddr/jobs/migrate_legacy_authorization.rb
+++ b/lib/ddr/jobs/migrate_legacy_authorization.rb
@@ -1,0 +1,20 @@
+module Ddr::Jobs
+  class MigrateLegacyAuthorization
+
+    @queue = :migration
+
+    SUMMARY = "Legacy authorization data migrated to roles"
+
+    def self.perform(pid)
+      obj = ActiveFedora::Base.find(pid)
+      detail = obj.legacy_authorization.migrate
+      obj.save!
+      Ddr::Notifications.notify_event(:update,
+                                      pid: pid,
+                                      summary: SUMMARY,
+                                      detail: detail
+                                     )
+    end
+
+  end
+end

--- a/lib/ddr/models/has_admin_metadata.rb
+++ b/lib/ddr/models/has_admin_metadata.rb
@@ -28,7 +28,7 @@ module Ddr
       end
 
       def roles
-        @roles ||= Ddr::Auth::Roles::PropertyRoleSet.new(adminMetadata.access_role)
+        Ddr::Auth::Roles::PropertyRoleSet.new(adminMetadata.access_role)
       end
 
       def workflow

--- a/spec/auth/legacy_authorization_spec.rb
+++ b/spec/auth/legacy_authorization_spec.rb
@@ -23,8 +23,27 @@ module Ddr::Auth
                                    {access: "read", type: "group", name: "registered"}]
       end
 
-      it "should convert the legacy authorization to roles" do
+      it "should convert the legacy authorization data to roles" do
         expect(subject.to_roles)
+          .to eq(Roles::DetachedRoleSet.new(
+                  [ Roles::Role.build(type: "Curator", agent: "Editors", scope: "policy"),
+                    Roles::Role.build(type: "Viewer", agent: "public", scope: "policy"),
+                    Roles::Role.build(type: "Viewer", agent: "registered", scope: "policy"),
+                    Roles::Role.build(type: "Editor", agent: "bob@example.com", scope: "resource") ]
+                ))
+      end
+
+      it "should clear the legacy authorization data" do
+        subject.clear
+        expect(obj.permissions).to be_empty
+        expect(obj.default_permissions).to be_empty
+        expect(obj.adminMetadata.downloader).to be_empty
+      end
+
+      it "should migrate the legacy authorization data" do
+        subject.migrate
+        expect(subject).to be_clear
+        expect(obj.roles)
           .to eq(Roles::DetachedRoleSet.new(
                   [ Roles::Role.build(type: "Curator", agent: "Editors", scope: "policy"),
                     Roles::Role.build(type: "Viewer", agent: "public", scope: "policy"),
@@ -51,7 +70,23 @@ module Ddr::Auth
                 ))
       end
 
-    end
+      it "should clear the legacy authorization data" do
+        subject.clear
+        expect(obj.permissions).to be_empty
+        expect(obj.adminMetadata.downloader).to be_empty
+      end
 
+      it "should migrate the legacy authorization data" do
+        subject.migrate
+        expect(subject).to be_clear
+        expect(obj.roles)
+          .to eq(Roles::DetachedRoleSet.new(
+                  [ Roles::Role.build(type: "Downloader", agent: "Downloaders", scope: "resource"),
+                    Roles::Role.build(type: "Downloader", agent: "sally@example.com", scope: "resource"),
+                    Roles::Role.build(type: "Editor", agent: "bob@example.com", scope: "resource") ]
+                ))
+      end
+
+    end
   end
 end

--- a/spec/auth/legacy_default_permissions_spec.rb
+++ b/spec/auth/legacy_default_permissions_spec.rb
@@ -27,5 +27,11 @@ module Ddr::Auth
               ))
     end
 
+    it "should clear the legacy default permissions" do
+      expect(obj.default_permissions).not_to be_empty
+      subject.clear
+      expect(obj.default_permissions).to be_empty
+    end
+
   end
 end

--- a/spec/auth/legacy_permissions_spec.rb
+++ b/spec/auth/legacy_permissions_spec.rb
@@ -27,5 +27,11 @@ module Ddr::Auth
               ))
     end
 
+    it "should clear the legacy permissions" do
+      expect(obj.permissions).not_to be_empty
+      subject.clear
+      expect(obj.permissions).to be_empty
+    end
+
   end
 end

--- a/spec/auth/legacy_roles_spec.rb
+++ b/spec/auth/legacy_roles_spec.rb
@@ -24,5 +24,9 @@ module Ddr::Auth
               ))
     end
 
+    it "should clear the legacy roles" do
+      expect { subject.clear }.to change(obj.adminMetadata.downloader, :empty?).from(false).to(true)
+    end
+
   end
 end

--- a/spec/jobs/migrate_legacy_authorization_spec.rb
+++ b/spec/jobs/migrate_legacy_authorization_spec.rb
@@ -1,0 +1,42 @@
+module Ddr::Jobs
+  RSpec.describe MigrateLegacyAuthorization do
+
+    let(:obj) { FactoryGirl.create(:collection) }
+
+    before do
+      @deprecation_behavior = Deprecation.default_deprecation_behavior
+      Deprecation.default_deprecation_behavior = :silence
+    end
+
+    after do
+      Deprecation.default_deprecation_behavior = @deprecation_behavior
+    end
+
+    it "should migrate the authorization data to roles" do
+      obj.permissions_attributes = [{access: "edit", type: "person", name: "bob@example.com"}]
+      obj.adminMetadata.downloader = ["Downloaders", "sally@example.com"]
+      obj.default_permissions = [{access: "edit", type: "group", name: "Editors"},
+                                 {access: "discover", type: "group", name: "public"},
+                                 {access: "read", type: "group", name: "registered"}]
+      obj.save!
+      Resque.enqueue(described_class, obj.pid)
+      obj.reload
+      expect(obj.legacy_authorization.clear?).to be true
+      expect(obj.roles)
+        .to eq(Ddr::Auth::Roles::DetachedRoleSet.new(
+                [ Ddr::Auth::Roles::Role.build(type: "Curator", agent: "Editors", scope: "policy"),
+                  Ddr::Auth::Roles::Role.build(type: "Viewer", agent: "public", scope: "policy"),
+                  Ddr::Auth::Roles::Role.build(type: "Viewer", agent: "registered", scope: "policy"),
+                  Ddr::Auth::Roles::Role.build(type: "Editor", agent: "bob@example.com", scope: "resource"),
+                  Ddr::Auth::Roles::Role.build(type: "Downloader", agent: "Downloaders", scope: "resource"),
+                  Ddr::Auth::Roles::Role.build(type: "Downloader", agent: "sally@example.com", scope: "resource")
+                ]
+              ))
+      event = obj.update_events.last
+      expect(event.summary).to eq("Legacy authorization data migrated to roles")
+      expect(event.detail).to match(/LEGACY AUTHORIZATION DATA/)
+      expect(event.detail).to match(/ROLES/)
+    end
+
+  end
+end


### PR DESCRIPTION
Note: An important bug was also fixed in Ddr::Models::HasAdminMetadata
which caused role information to remain stale following a reload.