### PR TITLE
Refactor StructDiv methods to return all nested objects; closes #278.

### DIFF
--- a/lib/ddr/models/struct_div.rb
+++ b/lib/ddr/models/struct_div.rb
@@ -2,7 +2,7 @@ module Ddr
   module Models
     class StructDiv
 
-      attr_accessor :id, :label, :order, :orderlabel, :type, :objs, :divs
+      attr_accessor :id, :label, :order, :orderlabel, :type, :fptrs, :divs
 
       def initialize(structmap_or_div_node)
         @id = structmap_or_div_node['ID']
@@ -10,7 +10,7 @@ module Ddr
         @order = structmap_or_div_node['ORDER']
         @orderlabel = structmap_or_div_node['ORDERLABEL']
         @type = structmap_or_div_node['TYPE']
-        @objs = obj_pids(structmap_or_div_node) if structmap_or_div_node.node_name == "div"
+        @fptrs = fptr_pids(structmap_or_div_node) if structmap_or_div_node.node_name == "div"
         @divs = subdivs(structmap_or_div_node).sort
       end
 
@@ -18,32 +18,40 @@ module Ddr
         self.order.to_i <=> other.order.to_i
       end
 
-      def objects?
-        objs.present?
+      def pids
+        collect_pids(self)
       end
 
-      def object_pids
-        objs
-      end
-
-      def object_docs
-        query = ActiveFedora::SolrService.construct_query_for_pids(object_pids)
+      def docs
+        query = ActiveFedora::SolrService.construct_query_for_pids(pids)
         results = ActiveFedora::SolrService.query(query, rows: 999999)
-        results.map { |r| ::SolrDocument.new(r) }
+        results.each_with_object({}) do |r, memo|
+          memo[r["id"]] = ::SolrDocument.new(r)
+        end
       end
 
       def objects
-        objs.map { |pid| ActiveFedora::Base.find(pid) }
+        pids.each_with_object({}) do |pid, memo|
+          memo[pid] = ActiveFedora::Base.find(pid)
+        end
       end
 
       private
 
-      def obj_pids(div_node)
+      def fptr_pids(div_node)
         div_node.xpath('xmlns:fptr').map { |fptr_node| fptr_node["CONTENTIDS"].gsub('info:fedora/', '') }
       end
 
       def subdivs(structmap_or_div_node)
         structmap_or_div_node.xpath('xmlns:div').map { |div_node| Ddr::Models::StructDiv.new(div_node) }
+      end
+
+      def collect_pids(structdiv)
+        pids = structdiv.divs.each_with_object([]) do |div, memo|
+          memo << collect_pids(div)
+        end
+        pids << structdiv.fptrs if structdiv.fptrs
+        pids.flatten
       end
 
     end


### PR DESCRIPTION
Changes also to some attribute and method names.