### PR TITLE
Refactored Ddr::Models::SolrDocument to remove deprecations

### DIFF
--- a/lib/ddr/index_fields.rb
+++ b/lib/ddr/index_fields.rb
@@ -5,6 +5,10 @@ module Ddr
       ActiveFedora::SolrService.solr_name(*args)
     end
 
+    def self.get(name)
+      const_get(name.to_s.upcase, false)
+    end
+
     ACCESS_ROLE                 = solr_name :access_role, :stored_sortable
     ACTIVE_FEDORA_MODEL         = solr_name :active_fedora_model, :stored_sortable
     ADMIN_SET                   = solr_name :admin_set, :stored_sortable

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -2,11 +2,33 @@ require 'spec_helper'
 
 RSpec.describe SolrDocument, type: :model, contacts: true do
 
+  describe "index field method access" do
+    describe "when there is an index field" do
+      before { Ddr::IndexFields.const_set(:FOO_BAR, "foo_bar_ssim") }
+      after { Ddr::IndexFields.send(:remove_const, :FOO_BAR) }
+      describe "and the field is not present" do
+        its(:foo_bar) { is_expected.to be_nil }
+      end
+      describe "and the field is a single value (not an array)" do
+        before { subject[Ddr::IndexFields::FOO_BAR] = "foo" }
+        its(:foo_bar) { is_expected.to eq("foo") }
+      end
+      describe "and the field value is an array" do
+        before { subject[Ddr::IndexFields::FOO_BAR] = ["foo", "bar"] }
+        its(:foo_bar) { is_expected.to eq("foo, bar") }
+      end
+    end
+    describe "when there is no index field" do
+      it "should raise an exception" do
+        expect { subject.foo_bar }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
   describe "#inherited_license" do
-    let(:apo_solr_response) { [{"system_create_dtsi"=>"2015-03-10T15:20:16Z", "system_modified_dtsi"=>"2015-03-10T15:21:50Z", "object_state_ssi"=>"A", "active_fedora_model_ssi"=>"Collection", "id"=>"changeme:224", "object_profile_ssm"=>["{\"datastreams\":{\"DC\":{\"dsLabel\":\"Dublin Core Record for this object\",\"dsVersionID\":\"DC1.0\",\"dsCreateDate\":\"2015-03-10T15:20:16Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":\"http://www.openarchives.org/OAI/2.0/oai_dc/\",\"dsControlGroup\":\"X\",\"dsSize\":341,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+DC+DC1.0\",\"dsLocationType\":null,\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"0555f020bbfc94c07745f530af4195fed9cf4e4ba539a30727f2d2d5743627be\"},\"RELS-EXT\":{\"dsLabel\":\"Fedora Object-to-Object Relationship Metadata\",\"dsVersionID\":\"RELS-EXT.1\",\"dsCreateDate\":\"2015-03-10T15:20:18Z\",\"dsState\":\"A\",\"dsMIME\":\"application/rdf+xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"X\",\"dsSize\":417,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+RELS-EXT+RELS-EXT.1\",\"dsLocationType\":null,\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"6a7c2621534cd1cb28d9cfa7e45bb128a1f3c05028e29def4dea479be9596d7d\"},\"descMetadata\":{\"dsLabel\":\"Descriptive Metadata for this object\",\"dsVersionID\":\"descMetadata.1\",\"dsCreateDate\":\"2015-03-10T15:20:18Z\",\"dsState\":\"A\",\"dsMIME\":\"application/n-triples\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":80,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+descMetadata+descMetadata.1\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"bbba526a1ca47f19dfe110f25a0a721bda481dc414f7ec89e3f02c5562eaa9a2\"},\"rightsMetadata\":{\"dsLabel\":null,\"dsVersionID\":\"rightsMetadata.0\",\"dsCreateDate\":\"2015-03-10T15:20:17Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":550,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+rightsMetadata+rightsMetadata.0\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"210d5a228bd96e22b20723de1dd20ea8d897252063713d0815369c49045c5c05\"},\"properties\":{},\"thumbnail\":{},\"adminMetadata\":{},\"defaultRights\":{\"dsLabel\":null,\"dsVersionID\":\"defaultRights.0\",\"dsCreateDate\":\"2015-03-10T15:21:50Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":634,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+defaultRights+defaultRights.0\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"1a2d9e665228d5e3cbf5f8ddd0d641172c20f98b4e05d62f741b7b9010696ad0\"}},\"objLabel\":null,\"objOwnerId\":\"fedoraAdmin\",\"objModels\":[\"info:fedora/afmodel:Collection\",\"info:fedora/fedora-system:FedoraObject-3.0\"],\"objCreateDate\":\"2015-03-10T15:20:16Z\",\"objLastModDate\":\"2015-03-10T15:20:18Z\",\"objDissIndexViewURL\":\"http://localhost:8983/fedora/objects/changeme%3A224/methods/fedora-system%3A3/viewMethodIndex\",\"objItemIndexViewURL\":\"http://localhost:8983/fedora/objects/changeme%3A224/methods/fedora-system%3A3/viewItemIndex\",\"objState\":\"A\"}"], "title_tesim"=>["Test Collection"], "edit_access_person_ssim"=>["coblej@duke.edu"], "inheritable_read_access_group_ssim"=>["public"], "is_governed_by_ssim"=>["info:fedora/changeme:224"], "has_model_ssim"=>["info:fedora/afmodel:Collection"], "title_ssi"=>"Test Collection", "internal_uri_ssi"=>"info:fedora/changeme:224", "default_license_description_tesim"=>["Default License Description"], "default_license_title_tesim"=>["Default License Title"], "default_license_url_tesim"=>["http://test.license.org/"], "_version_"=>1495270331036729344, "timestamp"=>"2015-03-10T15:21:50.793Z"}] }
+    let(:admin_policy) { described_class.new({"system_create_dtsi"=>"2015-03-10T15:20:16Z", "system_modified_dtsi"=>"2015-03-10T15:21:50Z", "object_state_ssi"=>"A", "active_fedora_model_ssi"=>"Collection", "id"=>"changeme:224", "object_profile_ssm"=>["{\"datastreams\":{\"DC\":{\"dsLabel\":\"Dublin Core Record for this object\",\"dsVersionID\":\"DC1.0\",\"dsCreateDate\":\"2015-03-10T15:20:16Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":\"http://www.openarchives.org/OAI/2.0/oai_dc/\",\"dsControlGroup\":\"X\",\"dsSize\":341,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+DC+DC1.0\",\"dsLocationType\":null,\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"0555f020bbfc94c07745f530af4195fed9cf4e4ba539a30727f2d2d5743627be\"},\"RELS-EXT\":{\"dsLabel\":\"Fedora Object-to-Object Relationship Metadata\",\"dsVersionID\":\"RELS-EXT.1\",\"dsCreateDate\":\"2015-03-10T15:20:18Z\",\"dsState\":\"A\",\"dsMIME\":\"application/rdf+xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"X\",\"dsSize\":417,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+RELS-EXT+RELS-EXT.1\",\"dsLocationType\":null,\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"6a7c2621534cd1cb28d9cfa7e45bb128a1f3c05028e29def4dea479be9596d7d\"},\"descMetadata\":{\"dsLabel\":\"Descriptive Metadata for this object\",\"dsVersionID\":\"descMetadata.1\",\"dsCreateDate\":\"2015-03-10T15:20:18Z\",\"dsState\":\"A\",\"dsMIME\":\"application/n-triples\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":80,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+descMetadata+descMetadata.1\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"bbba526a1ca47f19dfe110f25a0a721bda481dc414f7ec89e3f02c5562eaa9a2\"},\"rightsMetadata\":{\"dsLabel\":null,\"dsVersionID\":\"rightsMetadata.0\",\"dsCreateDate\":\"2015-03-10T15:20:17Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":550,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+rightsMetadata+rightsMetadata.0\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"210d5a228bd96e22b20723de1dd20ea8d897252063713d0815369c49045c5c05\"},\"properties\":{},\"thumbnail\":{},\"adminMetadata\":{},\"defaultRights\":{\"dsLabel\":null,\"dsVersionID\":\"defaultRights.0\",\"dsCreateDate\":\"2015-03-10T15:21:50Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":634,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+defaultRights+defaultRights.0\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"1a2d9e665228d5e3cbf5f8ddd0d641172c20f98b4e05d62f741b7b9010696ad0\"}},\"objLabel\":null,\"objOwnerId\":\"fedoraAdmin\",\"objModels\":[\"info:fedora/afmodel:Collection\",\"info:fedora/fedora-system:FedoraObject-3.0\"],\"objCreateDate\":\"2015-03-10T15:20:16Z\",\"objLastModDate\":\"2015-03-10T15:20:18Z\",\"objDissIndexViewURL\":\"http://localhost:8983/fedora/objects/changeme%3A224/methods/fedora-system%3A3/viewMethodIndex\",\"objItemIndexViewURL\":\"http://localhost:8983/fedora/objects/changeme%3A224/methods/fedora-system%3A3/viewItemIndex\",\"objState\":\"A\"}"], "title_tesim"=>["Test Collection"], "edit_access_person_ssim"=>["coblej@duke.edu"], "inheritable_read_access_group_ssim"=>["public"], "is_governed_by_ssim"=>["info:fedora/changeme:224"], "has_model_ssim"=>["info:fedora/afmodel:Collection"], "title_ssi"=>"Test Collection", "internal_uri_ssi"=>"info:fedora/changeme:224", "default_license_description_tesim"=>["Default License Description"], "default_license_title_tesim"=>["Default License Title"], "default_license_url_tesim"=>["http://test.license.org/"], "_version_"=>1495270331036729344, "timestamp"=>"2015-03-10T15:21:50.793Z"}) }
     before do
-      allow(subject).to receive(:admin_policy_pid).and_return('changeme:224')
-      allow(ActiveFedora::SolrService).to receive(:query).and_return(apo_solr_response)
+      allow(subject).to receive(:admin_policy) { admin_policy }
     end
     it "should return a hash of the default license attributes of the governing object" do
       expect(subject.inherited_license).to include(title: "Default License Title",
@@ -15,13 +37,29 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
     end
   end
 
-  describe "#permanent_id" do
-    before { subject[Ddr::IndexFields::PERMANENT_ID] = "foo" }
-    its(:permanent_id) { is_expected.to eq("foo") }
+  describe "#admin_policy_pid" do
+    describe "when is_governed_by is not set" do
+      its(:admin_policy_pid) { is_expected.to be_nil }
+    end
+    describe "when is_governed_by is set" do
+      before { subject[Ddr::IndexFields::IS_GOVERNED_BY] = "info:fedora/test:1" }
+      its(:admin_policy_pid) { should eq("test:1") }
+    end
+  end
+
+  describe "#admin_policy_uri" do
+    describe "when is_governed_by is not set" do
+      its(:admin_policy_uri) { is_expected.to be_nil }
+    end
+    describe "when is_governed_by is set" do
+      before { subject[Ddr::IndexFields::IS_GOVERNED_BY] = "info:fedora/test:1" }
+      its(:admin_policy_uri) { should eq("info:fedora/test:1") }
+    end
   end
 
   describe "#admin_policy" do
     describe "when there is not admin policy relationship" do
+      before { allow(subject).to receive(:admin_policy_pid) { nil } }
       its(:admin_policy) { should be_nil }
     end
     describe "where there is an admin policy relationship" do
@@ -35,16 +73,6 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
     end
   end
 
-  describe "#local_id" do
-    before { subject[Ddr::IndexFields::LOCAL_ID] = "abcdef" }
-    its(:local_id) { is_expected.to eq("abcdef") }
-  end
-
-  describe "#admin_set" do
-    before { subject[Ddr::IndexFields::ADMIN_SET] = "foobar" }
-    its(:admin_set) { should eq("foobar") }
-  end
-
   describe "#roles" do
     let(:json) { "[{\"role_type\":[\"Editor\"],\"agent\":[\"Editors\"],\"scope\":[\"policy\"]},{\"role_type\":[\"Contributor\"],\"agent\":[\"bob@example.com\"],\"scope\":[\"resource\"]}]" }
     before { subject[Ddr::IndexFields::ACCESS_ROLE] = json }
@@ -53,11 +81,6 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
         .to eq([Ddr::Auth::Roles::Role.build(type: "Editor", agent: "Editors", scope: "policy"),
                 Ddr::Auth::Roles::Role.build(type: "Contributor", agent: "bob@example.com", scope: "resource")])
     end
-  end
-
-  describe "#display_format" do
-    before { subject[Ddr::IndexFields::DISPLAY_FORMAT] = "Image" }
-    its(:display_format) { should eq("Image") }
   end
 
   describe "#struct_maps" do
@@ -95,11 +118,6 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
     end
   end
 
-  describe "#display_format" do
-    before { subject[Ddr::IndexFields::DISPLAY_FORMAT] = "Image" }
-    its(:display_format) { should eq("Image") }
-  end
-
   describe "contacts" do
     before do
       allow(YAML).to receive(:load_file) { { 'a' => { 'name' => 'Contact A', 'short_name' => 'A' },
@@ -115,10 +133,9 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
       end
       context "object does not have research help contact" do
         context "collection has research help contact" do
-          let(:apo_solr_response) { [{"system_create_dtsi"=>"2015-03-10T15:20:16Z", "system_modified_dtsi"=>"2015-03-10T15:21:50Z", "object_state_ssi"=>"A", "active_fedora_model_ssi"=>"Collection", "id"=>"changeme:224", "object_profile_ssm"=>["{\"datastreams\":{\"DC\":{\"dsLabel\":\"Dublin Core Record for this object\",\"dsVersionID\":\"DC1.0\",\"dsCreateDate\":\"2015-03-10T15:20:16Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":\"http://www.openarchives.org/OAI/2.0/oai_dc/\",\"dsControlGroup\":\"X\",\"dsSize\":341,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+DC+DC1.0\",\"dsLocationType\":null,\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"0555f020bbfc94c07745f530af4195fed9cf4e4ba539a30727f2d2d5743627be\"},\"RELS-EXT\":{\"dsLabel\":\"Fedora Object-to-Object Relationship Metadata\",\"dsVersionID\":\"RELS-EXT.1\",\"dsCreateDate\":\"2015-03-10T15:20:18Z\",\"dsState\":\"A\",\"dsMIME\":\"application/rdf+xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"X\",\"dsSize\":417,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+RELS-EXT+RELS-EXT.1\",\"dsLocationType\":null,\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"6a7c2621534cd1cb28d9cfa7e45bb128a1f3c05028e29def4dea479be9596d7d\"},\"descMetadata\":{\"dsLabel\":\"Descriptive Metadata for this object\",\"dsVersionID\":\"descMetadata.1\",\"dsCreateDate\":\"2015-03-10T15:20:18Z\",\"dsState\":\"A\",\"dsMIME\":\"application/n-triples\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":80,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+descMetadata+descMetadata.1\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"bbba526a1ca47f19dfe110f25a0a721bda481dc414f7ec89e3f02c5562eaa9a2\"},\"rightsMetadata\":{\"dsLabel\":null,\"dsVersionID\":\"rightsMetadata.0\",\"dsCreateDate\":\"2015-03-10T15:20:17Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":550,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+rightsMetadata+rightsMetadata.0\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"210d5a228bd96e22b20723de1dd20ea8d897252063713d0815369c49045c5c05\"},\"properties\":{},\"thumbnail\":{},\"adminMetadata\":{},\"defaultRights\":{\"dsLabel\":null,\"dsVersionID\":\"defaultRights.0\",\"dsCreateDate\":\"2015-03-10T15:21:50Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":634,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+defaultRights+defaultRights.0\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"1a2d9e665228d5e3cbf5f8ddd0d641172c20f98b4e05d62f741b7b9010696ad0\"}},\"objLabel\":null,\"objOwnerId\":\"fedoraAdmin\",\"objModels\":[\"info:fedora/afmodel:Collection\",\"info:fedora/fedora-system:FedoraObject-3.0\"],\"objCreateDate\":\"2015-03-10T15:20:16Z\",\"objLastModDate\":\"2015-03-10T15:20:18Z\",\"objDissIndexViewURL\":\"http://localhost:8983/fedora/objects/changeme%3A224/methods/fedora-system%3A3/viewMethodIndex\",\"objItemIndexViewURL\":\"http://localhost:8983/fedora/objects/changeme%3A224/methods/fedora-system%3A3/viewItemIndex\",\"objState\":\"A\"}"], "title_tesim"=>["Test Collection"], "edit_access_person_ssim"=>["coblej@duke.edu"], "inheritable_read_access_group_ssim"=>["public"], "is_governed_by_ssim"=>["info:fedora/changeme:224"], "has_model_ssim"=>["info:fedora/afmodel:Collection"], "title_ssi"=>"Test Collection", "internal_uri_ssi"=>"info:fedora/changeme:224", Ddr::IndexFields::RESEARCH_HELP_CONTACT=>["a"], "_version_"=>1495270331036729344, "timestamp"=>"2015-03-10T15:21:50.793Z"}] }
+          let(:admin_policy) { described_class.new({"system_create_dtsi"=>"2015-03-10T15:20:16Z", "system_modified_dtsi"=>"2015-03-10T15:21:50Z", "object_state_ssi"=>"A", "active_fedora_model_ssi"=>"Collection", "id"=>"changeme:224", "object_profile_ssm"=>["{\"datastreams\":{\"DC\":{\"dsLabel\":\"Dublin Core Record for this object\",\"dsVersionID\":\"DC1.0\",\"dsCreateDate\":\"2015-03-10T15:20:16Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":\"http://www.openarchives.org/OAI/2.0/oai_dc/\",\"dsControlGroup\":\"X\",\"dsSize\":341,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+DC+DC1.0\",\"dsLocationType\":null,\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"0555f020bbfc94c07745f530af4195fed9cf4e4ba539a30727f2d2d5743627be\"},\"RELS-EXT\":{\"dsLabel\":\"Fedora Object-to-Object Relationship Metadata\",\"dsVersionID\":\"RELS-EXT.1\",\"dsCreateDate\":\"2015-03-10T15:20:18Z\",\"dsState\":\"A\",\"dsMIME\":\"application/rdf+xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"X\",\"dsSize\":417,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+RELS-EXT+RELS-EXT.1\",\"dsLocationType\":null,\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"6a7c2621534cd1cb28d9cfa7e45bb128a1f3c05028e29def4dea479be9596d7d\"},\"descMetadata\":{\"dsLabel\":\"Descriptive Metadata for this object\",\"dsVersionID\":\"descMetadata.1\",\"dsCreateDate\":\"2015-03-10T15:20:18Z\",\"dsState\":\"A\",\"dsMIME\":\"application/n-triples\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":80,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+descMetadata+descMetadata.1\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"bbba526a1ca47f19dfe110f25a0a721bda481dc414f7ec89e3f02c5562eaa9a2\"},\"rightsMetadata\":{\"dsLabel\":null,\"dsVersionID\":\"rightsMetadata.0\",\"dsCreateDate\":\"2015-03-10T15:20:17Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":550,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+rightsMetadata+rightsMetadata.0\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"210d5a228bd96e22b20723de1dd20ea8d897252063713d0815369c49045c5c05\"},\"properties\":{},\"thumbnail\":{},\"adminMetadata\":{},\"defaultRights\":{\"dsLabel\":null,\"dsVersionID\":\"defaultRights.0\",\"dsCreateDate\":\"2015-03-10T15:21:50Z\",\"dsState\":\"A\",\"dsMIME\":\"text/xml\",\"dsFormatURI\":null,\"dsControlGroup\":\"M\",\"dsSize\":634,\"dsVersionable\":true,\"dsInfoType\":null,\"dsLocation\":\"changeme:224+defaultRights+defaultRights.0\",\"dsLocationType\":\"INTERNAL_ID\",\"dsChecksumType\":\"SHA-256\",\"dsChecksum\":\"1a2d9e665228d5e3cbf5f8ddd0d641172c20f98b4e05d62f741b7b9010696ad0\"}},\"objLabel\":null,\"objOwnerId\":\"fedoraAdmin\",\"objModels\":[\"info:fedora/afmodel:Collection\",\"info:fedora/fedora-system:FedoraObject-3.0\"],\"objCreateDate\":\"2015-03-10T15:20:16Z\",\"objLastModDate\":\"2015-03-10T15:20:18Z\",\"objDissIndexViewURL\":\"http://localhost:8983/fedora/objects/changeme%3A224/methods/fedora-system%3A3/viewMethodIndex\",\"objItemIndexViewURL\":\"http://localhost:8983/fedora/objects/changeme%3A224/methods/fedora-system%3A3/viewItemIndex\",\"objState\":\"A\"}"], "title_tesim"=>["Test Collection"], "edit_access_person_ssim"=>["coblej@duke.edu"], "inheritable_read_access_group_ssim"=>["public"], "is_governed_by_ssim"=>["info:fedora/changeme:224"], "has_model_ssim"=>["info:fedora/afmodel:Collection"], "title_ssi"=>"Test Collection", "internal_uri_ssi"=>"info:fedora/changeme:224", Ddr::IndexFields::RESEARCH_HELP_CONTACT=>["a"], "_version_"=>1495270331036729344, "timestamp"=>"2015-03-10T15:21:50.793Z"}) }
           before do
-            allow(subject).to receive(:admin_policy_pid).and_return('changeme:224')
-            allow(ActiveFedora::SolrService).to receive(:query).and_return(apo_solr_response)
+            allow(subject).to receive(:admin_policy) { admin_policy }
           end
           it "should return the collection's research help contact" do
             expect(subject.research_help.slug).to eq("a")


### PR DESCRIPTION
Explicitly defined methods that used the deprecated method
Blacklight::Solr::Document#get to return index field values
are now handled by method_missing.