### PR TITLE
Removes datastream metadata from media_type and file_size.

### DIFF
--- a/lib/ddr/datastreams/fits_datastream.rb
+++ b/lib/ddr/datastreams/fits_datastream.rb
@@ -12,7 +12,7 @@ module Ddr::Datastreams
       t.timestamp(path: {attribute: "timestamp"})
       t.identification {
         t.identity {
-          t.mimetype(path: {attribute: "mimetype"})
+          t.media_type(path: {attribute: "mimetype"})
           t.format_label(path: {attribute: "format"})
           t.format_version(path: "version")
           t.pronom_identifier(path: "externalIdentifier", attributes: {type: "puid"})

--- a/lib/ddr/managers/technical_metadata_manager.rb
+++ b/lib/ddr/managers/technical_metadata_manager.rb
@@ -15,7 +15,7 @@ module Ddr::Managers
     delegate :identity, to: :identification
 
     # FITS identity data points
-    delegate :mimetype, :format_label, :format_version, :pronom_identifier, to: :identity
+    delegate :media_type, :format_label, :format_version, :pronom_identifier, to: :identity
 
     # FITS fileinfo elements
     delegate :created, :last_modified, :creating_application, :size, to: :fileinfo
@@ -41,12 +41,8 @@ module Ddr::Managers
       end
     end
 
-    def media_type
-      mimetype.push(object.content_type).compact.uniq
-    end
-
     def file_size
-      size.map(&:to_i).push(object.content_size).compact.uniq
+      size.map(&:to_i)
     end
 
     def file_human_size

--- a/spec/managers/technical_metadata_manager_spec.rb
+++ b/spec/managers/technical_metadata_manager_spec.rb
@@ -11,7 +11,7 @@ module Ddr::Managers
       its(:valid) { is_expected.to be_empty }
       its(:well_formed) { is_expected.to be_empty }
       its(:format_label) { is_expected.to be_empty }
-      its(:mimetype) { is_expected.to be_empty }
+      its(:media_type) { is_expected.to be_empty }
       its(:format_version) { is_expected.to be_empty }
       its(:last_modified) { is_expected.to be_empty }
       its(:created) { is_expected.to be_empty }
@@ -35,7 +35,7 @@ module Ddr::Managers
       its(:valid) { is_expected.to eq(["false"]) }
       its(:well_formed) { is_expected.to eq(["true"]) }
       its(:format_label) { is_expected.to eq(["Portable Document Format"]) }
-      its(:mimetype) { is_expected.to eq(["application/pdf"]) }
+      its(:media_type) { is_expected.to eq(["application/pdf"]) }
       its(:format_version) { is_expected.to eq(["1.6"]) }
       its(:last_modified) { is_expected.to contain_exactly("2015:06:25 21:45:24-04:00", "2015-06-08T21:22:35Z") }
       its(:created) { is_expected.to eq(["2015:06:05 15:16:23-04:00"]) }


### PR DESCRIPTION
This is to avoid confusion about what constitutes technical metadata.