### PR TITLE
Fixes bug in Ddr::Auth::RoleBasedAccessControlsEnforcement#policy_role_filters

### DIFF
--- a/lib/ddr/auth/role_based_access_controls_enforcement.rb
+++ b/lib/ddr/auth/role_based_access_controls_enforcement.rb
@@ -17,15 +17,15 @@ module Ddr
         @current_ability ||= AbilityFactory.call(current_user, request.env)
       end
 
-      # List of PIDs for policies on which any of the current user's agent has a role in policy scope
+      # List of URIs for policies on which any of the current user's agent has a role in policy scope
       def policy_role_policies
-        @policy_role_policies ||= Array.new.tap do |pids|
+        @policy_role_policies ||= Array.new.tap do |uris|
           filters = current_ability.agents.map do |agent|
             "#{Ddr::IndexFields::POLICY_ROLE}:\"#{agent}\""
           end.join(" OR ")
           query = "#{Ddr::IndexFields::ACTIVE_FEDORA_MODEL}:Collection AND (#{filters})"
-          results = ActiveFedora::SolrService.query(query, rows: Collection.count, fl: "id")
-          results.each_with_object(pids) { |r, memo| memo << r["id"] }
+          results = ActiveFedora::SolrService.query(query, rows: Collection.count, fl: Ddr::IndexFields::INTERNAL_URI)
+          results.each_with_object(uris) { |r, memo| memo << r[Ddr::IndexFields::INTERNAL_URI] }
         end
       end
 

--- a/spec/controllers/including_role_based_access_controls_enforcement_spec.rb
+++ b/spec/controllers/including_role_based_access_controls_enforcement_spec.rb
@@ -31,17 +31,17 @@ RSpec.describe ApplicationController, type: :controller do
       collections[2].roles.grant type: "Viewer", agent: "foo:bar", scope: "policy"
       collections[2].save
     end
-    it "should return a list of PIDs for collections on which the current ability has a role" do
-      expect(subject.policy_role_policies).to match_array([collections[0].pid, collections[1].pid])
+    it "should return a list of internal URIs for collections on which the current ability has a role" do
+      expect(subject.policy_role_policies).to match_array([collections[0].internal_uri, collections[1].internal_uri])
     end
   end
 
   describe "#policy_role_filters" do
     before do
-      allow(subject).to receive(:policy_role_policies) { ["test:13", "test:45"] }
+      allow(subject).to receive(:policy_role_policies) { ["info:fedora/test:13", "info:fedora/test:45"] }
     end
-    it "should include clauses for is_governed_by relationships to the #policy_role_policies PIDs" do
-      expect(subject.policy_role_filters).to eq("_query_:\"{!raw f=#{Ddr::IndexFields::IS_GOVERNED_BY}}test:13\" OR _query_:\"{!raw f=#{Ddr::IndexFields::IS_GOVERNED_BY}}test:45\"")
+    it "should include clauses for is_governed_by relationships to the #policy_role_policies" do
+      expect(subject.policy_role_filters).to eq("_query_:\"{!raw f=#{Ddr::IndexFields::IS_GOVERNED_BY}}info:fedora/test:13\" OR _query_:\"{!raw f=#{Ddr::IndexFields::IS_GOVERNED_BY}}info:fedora/test:45\"")
     end
   end
 


### PR DESCRIPTION
Was causing policy roles not to be granted in gated discovery.
Fixes #318