### PR TITLE
Moves delegation of FITS terms to datastream, where it belongs.

### DIFF
--- a/lib/ddr/datastreams/fits_datastream.rb
+++ b/lib/ddr/datastreams/fits_datastream.rb
@@ -12,17 +12,18 @@ module Ddr::Datastreams
       t.timestamp(path: {attribute: "timestamp"})
       t.identification {
         t.identity {
-          t.media_type(path: {attribute: "mimetype"})
+          t.mimetype(path: {attribute: "mimetype"})
           t.format_label(path: {attribute: "format"})
-          t.format_version(path: "version")
+          t.version
+          t.externalIdentifier
           t.pronom_identifier(path: "externalIdentifier", attributes: {type: "puid"})
         }
       }
       t.fileinfo {
         t.size
-        t.creating_application(path: "creatingApplicationName")
+        t.creatingApplicationName
         t.created
-        t.last_modified(path: "lastmodified")
+        t.lastmodified
       }
       t.filestatus {
         t.valid
@@ -30,9 +31,9 @@ module Ddr::Datastreams
       }
       t.metadata {
         t.image {
-          t.image_width(path: "imageWidth")
-          t.image_height(path: "imageHeight")
-          t.color_space(path: "colorSpace")
+          t.imageWidth
+          t.imageHeight
+          t.colorSpace
         }
         t.document {
           # TODO - configure to get from Tika?
@@ -42,6 +43,25 @@ module Ddr::Datastreams
         t.audio
         t.video
       }
+
+      ## proxy terms
+      # identification / identity
+      t.media_type        proxy: [:identification, :identity, :mimetype]
+      t.format_label      proxy: [:identification, :identity, :format_label]
+      t.format_version    proxy: [:identification, :identity, :version]
+      t.pronom_identifier proxy: [:identification, :identity, :pronom_identifier]
+      # filestatus
+      t.valid             proxy: [:filestatus, :valid]
+      t.well_formed       proxy: [:filestatus, :well_formed]
+      # fileinfo
+      t.created              proxy: [:fileinfo, :created]
+      t.modified             proxy: [:fileinfo, :lastmodified]
+      t.creating_application proxy: [:fileinfo, :creatingApplicationName]
+      t.extent               proxy: [:fileinfo, :size]
+      # image metadata
+      t.image_width          proxy: [:metadata, :image, :imageWidth]
+      t.image_height         proxy: [:metadata, :image, :imageHeight]
+      t.color_space          proxy: [:metadata, :image, :colorSpace]
     end
 
     def self.xml_template

--- a/lib/ddr/managers/technical_metadata_manager.rb
+++ b/lib/ddr/managers/technical_metadata_manager.rb
@@ -5,26 +5,14 @@ module Ddr::Managers
 
     delegate :content, :fits, to: :object
 
-    # FITS output sections
-    delegate :filestatus, :fileinfo, :identification, :metadata, to: :fits
+    delegate :valid, :well_formed,
+             :media_type, :format_label, :format_version, :pronom_identifier,
+             :created, :modified, :creating_application, :extent,
+             :image_width, :image_height, :color_space,
+             to: :fits
 
-    # FITS filestatus section
-    delegate :valid, :well_formed, to: :filestatus
-
-    # FITS identification section
-    delegate :identity, to: :identification
-
-    # FITS identity data points
-    delegate :media_type, :format_label, :format_version, :pronom_identifier, to: :identity
-
-    # FITS fileinfo elements
-    delegate :created, :last_modified, :creating_application, :size, to: :fileinfo
-
-    # FITS format-specific metadata elements
-    delegate :image, :document, :text, :audio, :video, to: :metadata
-
-    # FITS image metadata elements
-    delegate :image_width, :image_height, :color_space, to: :image
+    alias_method :file_size, :extent
+    alias_method :last_modified, :modified
 
     def fits?
       !fits_version.nil?
@@ -41,14 +29,11 @@ module Ddr::Managers
       end
     end
 
-    def file_size
-      size.map(&:to_i)
-    end
-
     def file_human_size
-      file_size.map do |s|
-        "%s (%s bytes)" % [ ActiveSupport::NumberHelper.number_to_human_size(s),
-                            ActiveSupport::NumberHelper.number_to_delimited(s) ]
+      file_size.map do |fs|
+        num = fs.to_i
+        "%s (%s bytes)" % [ ActiveSupport::NumberHelper.number_to_human_size(n),
+                            ActiveSupport::NumberHelper.number_to_delimited(n) ]
       end
     end
 

--- a/spec/managers/technical_metadata_manager_spec.rb
+++ b/spec/managers/technical_metadata_manager_spec.rb
@@ -17,6 +17,7 @@ module Ddr::Managers
       its(:created) { is_expected.to be_empty }
       its(:pronom_identifier) { is_expected.to be_empty }
       its(:creating_application) { is_expected.to be_empty }
+      its(:file_size) { is_expected.to be_empty }
       its(:fits_version) { is_expected.to be_nil }
       its(:fits_datetime) { is_expected.to be_nil }
       its(:fits?) { is_expected.to be false }
@@ -42,7 +43,7 @@ module Ddr::Managers
       its(:pronom_identifier) { is_expected.to eq(["fmt/20"]) }
       its(:creating_application) { is_expected.to contain_exactly("Adobe Acrobat Pro 11.0.3 Paper Capture Plug-in/PREMIS Editorial Committee", "Adobe Acrobat Pro 11.0.3 Paper Capture Plug-in/Acrobat PDFMaker 11 for Word") }
       its(:fits_version) { is_expected.to eq("0.8.5") }
-      its(:file_size) { is_expected.to eq([3786205]) }
+      its(:file_size) { is_expected.to eq(["3786205"]) }
       its(:media_type) { is_expected.to eq(["application/pdf"]) }
     end
 


### PR DESCRIPTION
The API of TechnicalMetadataManager has not changed.