### PR TITLE
Adds `tempfile` method to DatastreamBehavior

### DIFF
--- a/lib/ddr/datastreams/datastream_behavior.rb
+++ b/lib/ddr/datastreams/datastream_behavior.rb
@@ -90,6 +90,19 @@ module Ddr
         [default_file_prefix, default_file_extension].join(".")
       end
 
+      def tempfile(prefix: nil, suffix: nil)
+        if empty?
+          raise Ddr::Models::Error, "Refusing to create tempfile for empty datastream!"
+        end
+        prefix ||= default_file_prefix + "--"
+        suffix ||= "." + default_file_extension
+        Tempfile.new [prefix, suffix], encoding: Encoding::ASCII_8BIT do |f|
+          f.write(content)
+          f.close
+          yield f
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Method yields a new (closed) tempfile containing the datastream content
to the block.  The tempfile is automatically removed on exiting the block.
An exception is raised if the datastream is empty.  The default file name
is prefixed by the pid (subbing _ for :) and suffixed by the extension
for the datastream media type.  Use the `:prefix` and `:suffix` options
to override.