### PR TITLE
New module Ddr::Index

### DIFF
--- a/lib/ddr/index.rb
+++ b/lib/ddr/index.rb
@@ -1,0 +1,20 @@
+module Ddr
+  module Index
+    extend ActiveSupport::Autoload
+
+    autoload :Connection
+    autoload :CSVQueryResult
+    autoload :DocumentBuilder
+    autoload :Field
+    autoload :Fields
+    autoload :Filter
+    autoload :Filters
+    autoload :Query
+    autoload :QueryBuilder
+    autoload :QueryResult
+    autoload :Response
+    autoload :RubyQueryResult
+    autoload :UniqueKeyField
+
+  end
+end

--- a/lib/ddr/index/connection.rb
+++ b/lib/ddr/index/connection.rb
@@ -1,0 +1,17 @@
+module Ddr::Index
+  class Connection < SimpleDelegator
+
+    def initialize
+      super RSolr.connect(ActiveFedora.solr_config)
+    end
+
+    def select(params, extra={})
+      Response.new get("select", params: params.merge(extra))
+    end
+
+    def page(*args)
+      Response.new paginate(*args)
+    end
+
+  end
+end

--- a/lib/ddr/index/csv_query_result.rb
+++ b/lib/ddr/index/csv_query_result.rb
@@ -1,0 +1,41 @@
+require "csv"
+
+module Ddr::Index
+  class CSVQueryResult < QueryResult
+
+    COL_SEP    = CSV::DEFAULT_OPTIONS[:col_sep]
+    QUOTE_CHAR = CSV::DEFAULT_OPTIONS[:quote_char]
+
+    SOLR_CSV_OPTS = {
+      "csv.header"       => "false",
+      "csv.separator"    => COL_SEP,
+      "csv.mv.separator" => "|",
+      "csv.encapsulator" => QUOTE_CHAR,
+      "wt"               => "csv",
+    }
+
+    def csv
+      CSV.new(data,
+              headers: headers,
+              return_headers: true,
+              write_headers: true,
+              col_sep: COL_SEP,
+              quote_char: QUOTE_CHAR)
+    end
+
+    def to_s
+      csv.read
+    end
+
+    def data
+      csv_params = params.merge(SOLR_CSV_OPTS)
+      csv_params[:rows] ||= MAX_ROWS
+      conn.get "select", params: csv_params
+    end
+
+    def headers
+      query.fields.map(&:label)
+    end
+
+  end
+end

--- a/lib/ddr/index/document_builder.rb
+++ b/lib/ddr/index/document_builder.rb
@@ -1,0 +1,9 @@
+module Ddr::Index
+  class DocumentBuilder
+
+    def self.build(doc)
+      SolrDocument.new(doc)
+    end
+
+  end
+end

--- a/lib/ddr/index/field.rb
+++ b/lib/ddr/index/field.rb
@@ -1,0 +1,23 @@
+module Ddr::Index
+  class Field < SimpleDelegator
+
+    attr_reader :base
+
+    def initialize(base, *args)
+      @base = base.to_s
+      name = if args.empty?
+               @base
+             elsif args.last.is_a?(Hash) && args.last[:solr_name]
+               args.last[:solr_name]
+             else
+               Solrizer.solr_name(base, *args)
+             end
+      super(name)
+    end
+
+    def label
+      I18n.t "ddr.index.fields.#{base}", default: base.titleize
+    end
+
+  end
+end

--- a/lib/ddr/index/fields.rb
+++ b/lib/ddr/index/fields.rb
@@ -1,0 +1,79 @@
+module Ddr::Index
+  module Fields
+
+    def self.get(name)
+      const_get(name.to_s.upcase, false)
+    end
+
+    ID = UniqueKeyField.instance
+    PID = UniqueKeyField.instance
+
+    ACCESS_ROLE                 = Field.new :access_role, :stored_sortable
+    ACTIVE_FEDORA_MODEL         = Field.new :active_fedora_model, :stored_sortable
+    ADMIN_SET                   = Field.new :admin_set, :stored_sortable
+    ADMIN_SET_FACET             = Field.new :admin_set_facet, :facetable
+    COLLECTION_FACET            = Field.new :collection_facet, :facetable
+    COLLECTION_URI              = Field.new :collection_uri, :symbol
+    CONTENT_CONTROL_GROUP       = Field.new :content_control_group, :searchable, type: :string
+    CONTENT_SIZE                = Field.new :content_size, :stored_sortable, type: :integer
+    CONTENT_SIZE_HUMAN          = Field.new :content_size_human, :symbol
+    CREATOR_FACET               = Field.new :creator_facet, :facetable
+    DATE_FACET                  = Field.new :date_facet, :facetable
+    DATE_SORT                   = Field.new :date_sort, :sortable
+    DEFAULT_LICENSE_DESCRIPTION = Field.new :default_license_description, type: :string
+    DEFAULT_LICENSE_TITLE       = Field.new :default_license_title, type: :string
+    DEFAULT_LICENSE_URL         = Field.new :default_license_url, type: :string
+    DISPLAY_FORMAT              = Field.new :display_format, :stored_sortable
+    EXTRACTED_TEXT              = Field.new :extracted_text, :searchable, type: :text
+    HAS_MODEL                   = Field.new :has_model, :symbol
+    IDENTIFIER_ALL              = Field.new :identifier_all, :symbol
+    INTERNAL_URI                = Field.new :internal_uri, :stored_sortable
+    IS_ATTACHED_TO              = Field.new :is_attached_to, :symbol
+    IS_EXTERNAL_TARGET_FOR      = Field.new :is_external_target_for, :symbol
+    IS_GOVERNED_BY              = Field.new :is_governed_by, :symbol
+    IS_MEMBER_OF                = Field.new :is_member_of, :symbol
+    IS_MEMBER_OF_COLLECTION     = Field.new :is_member_of_collection, :symbol
+    IS_PART_OF                  = Field.new :is_part_of, :symbol
+    LAST_FIXITY_CHECK_ON        = Field.new :last_fixity_check_on, :stored_sortable, type: :date
+    LAST_FIXITY_CHECK_OUTCOME   = Field.new :last_fixity_check_outcome, :symbol
+    LAST_VIRUS_CHECK_ON         = Field.new :last_virus_check_on, :stored_sortable, type: :date
+    LAST_VIRUS_CHECK_OUTCOME    = Field.new :last_virus_check_outcome, :symbol
+    LICENSE_DESCRIPTION         = Field.new :license_description, type: :string
+    LICENSE_TITLE               = Field.new :license_title, type: :string
+    LICENSE_URL                 = Field.new :license_url, type: :string
+    LOCAL_ID                    = Field.new :local_id, :stored_sortable
+    MEDIA_SUB_TYPE              = Field.new :content_media_sub_type, :facetable
+    MEDIA_MAJOR_TYPE            = Field.new :content_media_major_type, :facetable
+    MEDIA_TYPE                  = Field.new :content_media_type, :symbol
+    MULTIRES_IMAGE_FILE_PATH    = Field.new :multires_image_file_path, :stored_sortable
+    OBJECT_PROFILE              = Field.new :object_profile, :displayable
+    OBJECT_STATE                = Field.new :object_state, :stored_sortable
+    OBJECT_CREATE_DATE          = Field.new :system_create, :stored_sortable, type: :date
+    OBJECT_MODIFIED_DATE        = Field.new :system_modified, :stored_sortable, type: :date
+    PERMANENT_ID                = Field.new :permanent_id, :stored_sortable, type: :string
+    PERMANENT_URL               = Field.new :permanent_url, :stored_sortable, type: :string
+    POLICY_ROLE                 = Field.new :policy_role, :symbol
+    RESEARCH_HELP_CONTACT       = Field.new :research_help_contact, :stored_sortable
+    RESOURCE_ROLE               = Field.new :resource_role, :symbol
+    STRUCT_MAPS                 = Field.new :struct_maps, :stored_sortable
+    TECHMD_COLOR_SPACE          = Field.new :techmd_color_space, :symbol
+    TECHMD_CREATING_APPLICATION = Field.new :techmd_creating_application, :symbol
+    TECHMD_CREATION_TIME        = Field.new :techmd_creation_time, :stored_searchable, type: :date
+    TECHMD_FILE_SIZE            = Field.new :techmd_file_size, :stored_searchable, type: :integer
+    TECHMD_FITS_VERSION         = Field.new :techmd_fits_version, :stored_sortable
+    TECHMD_FITS_DATETIME        = Field.new :techmd_fits_datetime, :stored_sortable, type: :date
+    TECHMD_FORMAT_LABEL         = Field.new :techmd_format_label, :symbol
+    TECHMD_FORMAT_VERSION       = Field.new :techmd_format_version, :symbol
+    TECHMD_IMAGE_HEIGHT         = Field.new :techmd_image_height, :stored_searchable, type: :integer
+    TECHMD_IMAGE_WIDTH          = Field.new :techmd_image_width, :stored_searchable, type: :integer
+    TECHMD_MEDIA_TYPE           = Field.new :techmd_media_type, :symbol
+    TECHMD_MODIFICATION_TIME    = Field.new :techmd_modification_time, :stored_searchable, type: :date
+    TECHMD_PRONOM_IDENTIFIER    = Field.new :techmd_pronom_identifier, :symbol
+    TECHMD_VALID                = Field.new :techmd_valid, :symbol
+    TECHMD_WELL_FORMED          = Field.new :techmd_well_formed, :symbol
+    TITLE                       = Field.new :title, :stored_sortable
+    WORKFLOW_STATE              = Field.new :workflow_state, :stored_sortable
+    YEAR_FACET                  = Field.new :year_facet, solr_name: "year_facet_iim"
+
+  end
+end

--- a/lib/ddr/index/filter.rb
+++ b/lib/ddr/index/filter.rb
@@ -1,0 +1,38 @@
+module Ddr::Index
+  class Filter
+
+    class << self
+      def where(conditions)
+        new.where(conditions)
+      end
+
+      def raw(*clauses)
+        new.raw(*clauses)
+      end
+    end
+
+    attr_accessor :clauses
+
+    def initialize
+      @clauses = [ ]
+    end
+
+    def where(conditions)
+      clauses = conditions.map { |field, value| raw_query(field, value) }
+      raw(*clauses)
+    end
+
+    def raw(*clauses)
+      self.clauses += clauses
+      self
+    end
+
+    private
+
+    # Copied from ActiveFedora::SolrService
+    def raw_query(key, value)
+      "_query_:\"{!raw f=#{key}}#{value.gsub('"', '\"')}\""
+    end
+
+  end
+end

--- a/lib/ddr/index/filters.rb
+++ b/lib/ddr/index/filters.rb
@@ -1,0 +1,21 @@
+module Ddr::Index
+  module Filters
+
+    HAS_CONTENT = Filter.raw(
+      "%s:(Component OR Attachment OR Target)" % Fields::ACTIVE_FEDORA_MODEL
+    )
+
+    class << self
+      def is_governed_by(pid)
+        Filter.where Fields::IS_GOVERNED_BY => internal_uri(pid)
+      end
+
+      def internal_uri(pid)
+        ActiveFedora::Base.internal_uri(pid)
+      end
+    end
+
+    private_class_method :internal_uri
+
+  end
+end

--- a/lib/ddr/index/query.rb
+++ b/lib/ddr/index/query.rb
@@ -1,0 +1,46 @@
+module Ddr::Index
+  class Query
+
+    attr_reader :q, :fields, :filters, :sort, :limit
+
+    delegate :count, :docs, :all, to: :result
+
+    def inspect
+      "#<#{self.class.name} q=#{q.inspect}, filters=#{filters.inspect}," \
+      " sort=#{sort.inspect}, limit=#{limit.inspect}, fields=#{fields.inspect}>"
+    end
+
+    def to_s
+      URI.encode_www_form(params)
+    end
+
+    def params
+      base_params.tap do |p|
+        if filters.present?
+          p[:fq] = filters.map(&:clauses).flatten
+        end
+        if sort.present?
+          p[:sort] = sort.join(",")
+        end
+        if limit
+          p[:rows] = limit
+        end
+      end
+    end
+
+    def result
+      RubyQueryResult.new(self)
+    end
+
+    def csv
+      CSVQueryResult.new(self)
+    end
+
+    private
+
+    def base_params
+      { q: q, fl: fields }
+    end
+
+  end
+end

--- a/lib/ddr/index/query_builder.rb
+++ b/lib/ddr/index/query_builder.rb
@@ -1,0 +1,59 @@
+module Ddr::Index
+  class QueryBuilder
+
+    attr_accessor :q, :fields, :filters, :sort, :limit
+
+    def initialize
+      @q       = "*:*"
+      @fields  = [ Fields::PID ]
+      @filters = [ ]
+      @sort    = [ ]
+      @limit   = nil
+    end
+
+    def query
+      Query.new.tap do |q|
+        instance_variables.each do |var|
+          q.instance_variable_set(var, instance_variable_get(var))
+        end
+      end
+    end
+
+    def filter(*filters)
+      self.filters += filters
+      self
+    end
+
+    def fields(*fields)
+      self.fields += fields
+      self
+    end
+    alias_method :field, :fields
+
+    def limit(num)
+      self.limit = num
+      self
+    end
+
+    def sort(*orderings)
+      self.sort += orderings
+      self
+    end
+
+    # @param conditions [Hash]
+    def where(conditions)
+      filter Filter.where(conditions)
+    end
+
+    # for adding raw string filters
+    def raw(*clauses)
+      filter Filter.raw(*clauses)
+    end
+
+    def q(q)
+      self.q = q
+      self
+    end
+
+  end
+end

--- a/lib/ddr/index/query_result.rb
+++ b/lib/ddr/index/query_result.rb
@@ -1,0 +1,20 @@
+module Ddr::Index
+  class QueryResult
+
+    MAX_ROWS = 10**7
+
+    attr_reader :query, :conn
+    delegate :params, to: :query
+
+    def initialize(query)
+      @query = query
+      @conn = Connection.new
+    end
+
+    def count
+      response = conn.select(params, rows: 0)
+      response.num_found
+    end
+
+  end
+end

--- a/lib/ddr/index/response.rb
+++ b/lib/ddr/index/response.rb
@@ -1,0 +1,13 @@
+module Ddr::Index
+  class Response < SimpleDelegator
+
+    def docs
+      self["response"]["docs"]
+    end
+
+    def num_found
+      self["response"]["numFound"].to_i
+    end
+
+  end
+end

--- a/lib/ddr/index/ruby_query_result.rb
+++ b/lib/ddr/index/ruby_query_result.rb
@@ -1,0 +1,58 @@
+module Ddr::Index
+  class RubyQueryResult < QueryResult
+    include Enumerable
+
+    def each(&block)
+      if params[:rows]
+        each_unpaginated(&block)
+      else
+        each_paginated(&block)
+      end
+    end
+
+    def each_unpaginated
+      _params = {rows: MAX_ROWS}.merge(params)
+      response = conn.select(_params)
+      response.docs.each { |doc| yield(doc) }
+    end
+
+    def each_paginated
+      pages.each do |pg|
+        pg.each do |doc|
+          yield doc
+        end
+      end
+    end
+
+    def docs
+      each do |doc|
+        yield DocumentBuilder.build(doc)
+      end
+    end
+
+    def all
+      to_a
+    end
+
+    def pages
+      num = 1
+      Enumerator.new do |enum|
+        loop do
+          pg = page(num)
+          enum << pg
+          if pg.has_next?
+            num += 1
+          else
+            break
+          end
+        end
+      end
+    end
+
+    def page(num)
+      response = conn.page num, PAGE_SIZE, "select", params: params
+      response.docs
+    end
+
+  end
+end

--- a/lib/ddr/index/unique_key_field.rb
+++ b/lib/ddr/index/unique_key_field.rb
@@ -1,0 +1,12 @@
+require 'singleton'
+
+module Ddr::Index
+  class UniqueKeyField < Field
+    include Singleton
+
+    def initialize
+      super SOLR_DOCUMENT_ID
+    end
+
+  end
+end

--- a/lib/ddr/index_fields.rb
+++ b/lib/ddr/index_fields.rb
@@ -1,80 +1,14 @@
 module Ddr
   module IndexFields
 
-    def self.solr_name(*args)
-      ActiveFedora::SolrService.solr_name(*args)
-    end
+    warn "[DEPRECATION] `Ddr::IndexFields` is deprecated and will be removed in ddr-models 3.0." \
+         " Use `Ddr::Index::Fields` instead."
+
+    include Ddr::Index::Fields
 
     def self.get(name)
-      const_get(name.to_s.upcase, false)
+      Ddr::Index::Fields.get(name)
     end
-
-    ACCESS_ROLE                 = solr_name :access_role, :stored_sortable
-    ACTIVE_FEDORA_MODEL         = solr_name :active_fedora_model, :stored_sortable
-    ADMIN_SET                   = solr_name :admin_set, :stored_sortable
-    ADMIN_SET_FACET             = solr_name :admin_set_facet, :facetable
-    COLLECTION_FACET            = solr_name :collection_facet, :facetable
-    COLLECTION_URI              = solr_name :collection_uri, :symbol
-    CONTENT_CONTROL_GROUP       = solr_name :content_control_group, :searchable, type: :string
-    CONTENT_SIZE                = solr_name :content_size, :stored_sortable, type: :integer
-    CONTENT_SIZE_HUMAN          = solr_name :content_size_human, :symbol
-    CREATOR_FACET               = solr_name :creator_facet, :facetable
-    DATE_FACET                  = solr_name :date_facet, :facetable
-    DATE_SORT                   = solr_name :date_sort, :sortable
-    DEFAULT_LICENSE_DESCRIPTION = solr_name :default_license_description, type: :string
-    DEFAULT_LICENSE_TITLE       = solr_name :default_license_title, type: :string
-    DEFAULT_LICENSE_URL         = solr_name :default_license_url, type: :string
-    DISPLAY_FORMAT              = solr_name :display_format, :stored_sortable
-    EXTRACTED_TEXT              = solr_name :extracted_text, :searchable, type: :text
-    HAS_MODEL                   = solr_name :has_model, :symbol
-    IDENTIFIER_ALL              = solr_name :identifier_all, :symbol
-    INTERNAL_URI                = solr_name :internal_uri, :stored_sortable
-    IS_ATTACHED_TO              = solr_name :is_attached_to, :symbol
-    IS_EXTERNAL_TARGET_FOR      = solr_name :is_external_target_for, :symbol
-    IS_GOVERNED_BY              = solr_name :is_governed_by, :symbol
-    IS_MEMBER_OF                = solr_name :is_member_of, :symbol
-    IS_MEMBER_OF_COLLECTION     = solr_name :is_member_of_collection, :symbol
-    IS_PART_OF                  = solr_name :is_part_of, :symbol
-    LAST_FIXITY_CHECK_ON        = solr_name :last_fixity_check_on, :stored_sortable, type: :date
-    LAST_FIXITY_CHECK_OUTCOME   = solr_name :last_fixity_check_outcome, :symbol
-    LAST_VIRUS_CHECK_ON         = solr_name :last_virus_check_on, :stored_sortable, type: :date
-    LAST_VIRUS_CHECK_OUTCOME    = solr_name :last_virus_check_outcome, :symbol
-    LICENSE_DESCRIPTION         = solr_name :license_description, type: :string
-    LICENSE_TITLE               = solr_name :license_title, type: :string
-    LICENSE_URL                 = solr_name :license_url, type: :string
-    LOCAL_ID                    = solr_name :local_id, :stored_sortable
-    MEDIA_SUB_TYPE              = solr_name :content_media_sub_type, :facetable
-    MEDIA_MAJOR_TYPE            = solr_name :content_media_major_type, :facetable
-    MEDIA_TYPE                  = solr_name :content_media_type, :symbol
-    MULTIRES_IMAGE_FILE_PATH    = solr_name :multires_image_file_path, :stored_sortable
-    OBJECT_PROFILE              = solr_name :object_profile, :displayable
-    OBJECT_STATE                = solr_name :object_state, :stored_sortable
-    OBJECT_CREATE_DATE          = solr_name :system_create, :stored_sortable, type: :date
-    OBJECT_MODIFIED_DATE        = solr_name :system_modified, :stored_sortable, type: :date
-    PERMANENT_ID                = solr_name :permanent_id, :stored_sortable, type: :string
-    PERMANENT_URL               = solr_name :permanent_url, :stored_sortable, type: :string
-    POLICY_ROLE                 = solr_name :policy_role, :symbol
-    RESEARCH_HELP_CONTACT       = solr_name :research_help_contact, :stored_sortable
-    RESOURCE_ROLE               = solr_name :resource_role, :symbol
-    STRUCT_MAPS                 = solr_name :struct_maps, :stored_sortable
-    TECHMD_COLOR_SPACE          = solr_name :techmd_color_space, :symbol
-    TECHMD_CREATING_APPLICATION = solr_name :techmd_creating_application, :symbol
-    TECHMD_CREATION_TIME        = solr_name :techmd_creation_time, :stored_searchable, type: :date
-    TECHMD_FILE_SIZE            = solr_name :techmd_file_size, :stored_searchable, type: :integer
-    TECHMD_FITS_VERSION         = solr_name :techmd_fits_version, :stored_sortable
-    TECHMD_FITS_DATETIME        = solr_name :techmd_fits_datetime, :stored_sortable, type: :date
-    TECHMD_FORMAT_LABEL         = solr_name :techmd_format_label, :symbol
-    TECHMD_FORMAT_VERSION       = solr_name :techmd_format_version, :symbol
-    TECHMD_IMAGE_HEIGHT         = solr_name :techmd_image_height, :stored_searchable, type: :integer
-    TECHMD_IMAGE_WIDTH          = solr_name :techmd_image_width, :stored_searchable, type: :integer
-    TECHMD_MEDIA_TYPE           = solr_name :techmd_media_type, :symbol
-    TECHMD_MODIFICATION_TIME    = solr_name :techmd_modification_time, :stored_searchable, type: :date
-    TECHMD_PRONOM_IDENTIFIER    = solr_name :techmd_pronom_identifier, :symbol
-    TECHMD_VALID                = solr_name :techmd_valid, :symbol
-    TECHMD_WELL_FORMED          = solr_name :techmd_well_formed, :symbol
-    TITLE                       = solr_name :title, :stored_sortable
-    WORKFLOW_STATE              = solr_name :workflow_state, :stored_sortable
-    YEAR_FACET                  = "year_facet_iim"
 
   end
 end

--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -9,32 +9,36 @@ require 'active_record'
 require 'hydra-core'
 require 'hydra/validations'
 
-require 'ddr/actions'
-require 'ddr/auth'
-require 'ddr/contacts'
-require 'ddr/datastreams'
-require 'ddr/derivatives'
-require 'ddr/events'
-require 'ddr/index_fields'
-require 'ddr/jobs'
-require 'ddr/managers'
-require 'ddr/metadata'
-require 'ddr/notifications'
-require 'ddr/utils'
-require 'ddr/vocab'
-
 module Ddr
+  extend ActiveSupport::Autoload
+
+  autoload :Actions
+  autoload :Auth
+  autoload :Contacts
+  autoload :Datastreams
+  autoload :Derivatives
+  autoload :Events
+  autoload :Index
+  autoload :IndexFields
+  autoload :Jobs
+  autoload :Managers
+  autoload :Metadata
+  autoload :Notifications
+  autoload :Utils
+  autoload :Vocab
+
   module Models
     extend ActiveSupport::Autoload
 
-    autoload :Base
     autoload :AccessControllable
-    autoload :Describable
-    autoload :EventLoggable
-    autoload :Error
+    autoload :Base
     autoload :ChecksumInvalid, 'ddr/models/error'
-    autoload :DerivativeGenerationFailure, 'ddr/models/error'
     autoload :ContentModelError, 'ddr/models/error'
+    autoload :DerivativeGenerationFailure, 'ddr/models/error'
+    autoload :Describable
+    autoload :Error
+    autoload :EventLoggable
+    autoload :FileManagement
     autoload :FixityCheckable
     autoload :Governable
     autoload :HasAdminMetadata
@@ -46,11 +50,10 @@ module Ddr
     autoload :HasStructMetadata
     autoload :HasThumbnail
     autoload :Indexing
-    autoload :FileManagement
     autoload :Licensable
     autoload :SolrDocument
-    autoload :Structure
     autoload :StructDiv
+    autoload :Structure
     autoload :YearFacet
 
     # Base directory of default external file store

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
 
   describe "index field method access" do
     describe "when there is an index field" do
-      before { Ddr::IndexFields.const_set(:FOO_BAR, "foo_bar_ssim") }
-      after { Ddr::IndexFields.send(:remove_const, :FOO_BAR) }
+      before { Ddr::Index::Fields.const_set(:FOO_BAR, "foo_bar_ssim") }
+      after { Ddr::Index::Fields.send(:remove_const, :FOO_BAR) }
       describe "and the field is not present" do
         its(:foo_bar) { is_expected.to be_nil }
       end
       describe "and the field is a single value (not an array)" do
-        before { subject[Ddr::IndexFields::FOO_BAR] = "foo" }
+        before { subject[Ddr::Index::Fields::FOO_BAR] = "foo" }
         its(:foo_bar) { is_expected.to eq("foo") }
       end
       describe "and the field value is an array" do
-        before { subject[Ddr::IndexFields::FOO_BAR] = ["foo", "bar"] }
+        before { subject[Ddr::Index::Fields::FOO_BAR] = ["foo", "bar"] }
         its(:foo_bar) { is_expected.to eq("foo, bar") }
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
       its(:admin_policy_pid) { is_expected.to be_nil }
     end
     describe "when is_governed_by is set" do
-      before { subject[Ddr::IndexFields::IS_GOVERNED_BY] = "info:fedora/test:1" }
+      before { subject[Ddr::Index::Fields::IS_GOVERNED_BY] = "info:fedora/test:1" }
       its(:admin_policy_pid) { should eq("test:1") }
     end
   end
@@ -52,7 +52,7 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
       its(:admin_policy_uri) { is_expected.to be_nil }
     end
     describe "when is_governed_by is set" do
-      before { subject[Ddr::IndexFields::IS_GOVERNED_BY] = "info:fedora/test:1" }
+      before { subject[Ddr::Index::Fields::IS_GOVERNED_BY] = "info:fedora/test:1" }
       its(:admin_policy_uri) { should eq("info:fedora/test:1") }
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
     describe "where there is an admin policy relationship" do
       let(:admin_policy) { FactoryGirl.create(:collection) }
       before do
-        subject[Ddr::IndexFields::IS_GOVERNED_BY] = [ admin_policy.internal_uri ]
+        subject[Ddr::Index::Fields::IS_GOVERNED_BY] = [ admin_policy.internal_uri ]
       end
       it "should get the admin policy document" do
         expect(subject.admin_policy.id).to eq(admin_policy.id)
@@ -75,7 +75,7 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
 
   describe "#roles" do
     let(:json) { "[{\"role_type\":[\"Editor\"],\"agent\":[\"Editors\"],\"scope\":[\"policy\"]},{\"role_type\":[\"Contributor\"],\"agent\":[\"bob@example.com\"],\"scope\":[\"resource\"]}]" }
-    before { subject[Ddr::IndexFields::ACCESS_ROLE] = json }
+    before { subject[Ddr::Index::Fields::ACCESS_ROLE] = json }
     it "should deserialize the roles from JSON" do
       expect(subject.roles.to_a)
         .to eq([Ddr::Auth::Roles::Role.build(type: "Editor", agent: "Editors", scope: "policy"),
@@ -90,7 +90,7 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
       end
     end
     context "indexed struct maps" do
-      before { subject[Ddr::IndexFields::STRUCT_MAPS] = multiple_struct_maps_structure_to_json }
+      before { subject[Ddr::Index::Fields::STRUCT_MAPS] = multiple_struct_maps_structure_to_json }
       it "should return a hash of the struct maps" do
         expect(subject.struct_maps).to eq(JSON.parse(multiple_struct_maps_structure_to_json))
       end
@@ -104,7 +104,7 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
       end
     end
     context "indexed struct maps" do
-      before { subject[Ddr::IndexFields::STRUCT_MAPS] = multiple_struct_maps_structure_to_json }
+      before { subject[Ddr::Index::Fields::STRUCT_MAPS] = multiple_struct_maps_structure_to_json }
       context "requested struct map is indexed" do
         it "should return the struct map" do
           expect(subject.struct_map('default')).to eq(JSON.parse(multiple_struct_maps_structure_to_json)["default"])
@@ -126,14 +126,14 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
     end
     describe "#research_help" do
       context "object has research help contact" do
-        before { subject[Ddr::IndexFields::RESEARCH_HELP_CONTACT] = 'yb' }
+        before { subject[Ddr::Index::Fields::RESEARCH_HELP_CONTACT] = 'yb' }
         it "should return the object's research help contact" do
           expect(subject.research_help.slug).to eq('yb')
         end
       end
       context "object does not have research help contact" do
         context "collection has research help contact" do
-          let(:admin_policy) { described_class.new({Ddr::IndexFields::RESEARCH_HELP_CONTACT=>["xa"]}) }
+          let(:admin_policy) { described_class.new({Ddr::Index::Fields::RESEARCH_HELP_CONTACT=>["xa"]}) }
           before do
             allow(subject).to receive(:admin_policy) { admin_policy }
           end


### PR DESCRIPTION
Ddr::IndexFields is now deprecated; use Ddr::Index::Fields.
Ddr::Index::Query is a first cut at encapsulating index query formulation.