### PR TITLE
Adds methods for enumerating pids

### DIFF
--- a/lib/ddr/index.rb
+++ b/lib/ddr/index.rb
@@ -16,5 +16,11 @@ module Ddr
     autoload :RubyQueryResult
     autoload :UniqueKeyField
 
+    def self.pids(&block)
+      builder = QueryBuilder.new
+      query = builder.query
+      query.pids(&block)
+    end
+
   end
 end

--- a/lib/ddr/index/query.rb
+++ b/lib/ddr/index/query.rb
@@ -3,7 +3,7 @@ module Ddr::Index
 
     attr_reader :q, :fields, :filters, :sort, :limit
 
-    delegate :count, :docs, :all, to: :result
+    delegate :count, :docs, :pids, :all, to: :result
 
     def inspect
       "#<#{self.class.name} q=#{q.inspect}, filters=#{filters.inspect}," \

--- a/lib/ddr/index/query_result.rb
+++ b/lib/ddr/index/query_result.rb
@@ -2,6 +2,7 @@ module Ddr::Index
   class QueryResult
 
     MAX_ROWS = 10**7
+    PAGE_SIZE = 1000
 
     attr_reader :query, :conn
     delegate :params, to: :query

--- a/lib/ddr/index/ruby_query_result.rb
+++ b/lib/ddr/index/ruby_query_result.rb
@@ -24,6 +24,12 @@ module Ddr::Index
       end
     end
 
+    def pids
+      each do |doc|
+        yield doc[Fields::PID]
+      end
+    end
+
     def docs
       each do |doc|
         yield DocumentBuilder.build(doc)


### PR DESCRIPTION
`Ddr::Index::RubyQueryResult#pids` yields the pids from the result documents.
`Ddr::Index.pids` yields the pids for all docs in the index.