### PR TITLE
Removes unused and improperly deprecated method

### DIFF
--- a/lib/ddr/models/solr_document.rb
+++ b/lib/ddr/models/solr_document.rb
@@ -164,11 +164,6 @@ module Ddr::Models
       active_fedora_model.tableize
     end
 
-    def inherited_license
-      warn "[DEPRECATION] `inherited_licensed` is deprecated and will be removed from ddr-models 3.0." \
-           " Use `effective_license` instead."
-    end
-
     def effective_license
       @effective_license ||= EffectiveLicense.call(self)
     end


### PR DESCRIPTION
`Ddr::Models::SolrDocument#inherited_license` was improperly deprecated (emits warning w/o current behavior).  Since it appears not to be used by dul-hydra or ddr-public, the method is simply removed.