### PR TITLE
Restores usage of ddr-antivirus, now at v2.0.0.rc2.

### DIFF
--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency "net-ldap", "~> 0.11"
   s.add_dependency "cancancan", "~> 1.12"
   s.add_dependency "ddr-aux-client", "~> 1.0"
+  s.add_dependency "ddr-antivirus", "2.0.0.rc2"
 
   s.add_development_dependency "bundler", "~> 1.7"
   s.add_development_dependency "rake"

--- a/lib/ddr/actions/virus_check.rb
+++ b/lib/ddr/actions/virus_check.rb
@@ -5,63 +5,23 @@ require "shellwords"
 module Ddr::Actions
   class VirusCheck
 
-    # Virus check errors
-    class Error < Ddr::Models::Error; end
-
-    # Virus found
-    class VirusFound < Error; end
-
-    # Virus scanner error
-    class ScannerError < Error; end
-
-    # Virus scanner software not found
-    class ScannerNotFound < Error; end
-
-    SCANNER = "clamdscan"
-
-    class << self
-
-      def call(file_path)
-        unless File.exist?(file_path)
-          raise Error, "File not found: #{file_path}"
-        end
-
-        result = OpenStruct.new
-        result.event_date_time = Time.now.utc
-        begin
-          output, status = scan(file_path)
-        rescue Errno::ENOENT
-          exc = ScannerNotFound.new "Scanner `#{SCANNER}` not found on path."
-          logger.error exc
-          result.exception = exc
-        else
-          case status.exitstatus
-          when 1
-            raise VirusFound, output
-          when 2
-            exc = ScannerError.new output
-            logger.error exc
-            result.exception = exc
-          end
-          result.software = version
-          result.detail = output
-        end
-        result.to_h
+    # @return [Hash] result data
+    # @raises [Ddr::Antivirus::VirusFoundError]
+    def self.call(file_path)
+      unless File.exist?(file_path)
+        raise Error, "File not found: #{file_path}"
       end
-
-      def version
-        Open3.capture2(SCANNER, "-V").first.strip
+      result = {}
+      begin
+        scan_result = Ddr::Antivirus.scan(file_path)
+      rescue Ddr::Antivirus::ScannerError => e
+        result[:exception] = [e.class.name, e.to_s]
+        scan_result = e.result
       end
-
-      def scan(path)
-        safe_path = Shellwords.shellescape(path)
-        Open3.capture2e(SCANNER, safe_path)
-      end
-
-      def logger
-        Rails.logger
-      end
-
+      result[:event_date_time] = scan_result.scanned_at
+      result[:software]        = scan_result.version
+      result[:detail]          = scan_result.output
+      result
     end
 
   end

--- a/lib/ddr/models/engine.rb
+++ b/lib/ddr/models/engine.rb
@@ -83,6 +83,15 @@ module Ddr
         Ddr::Models.fits_home = ENV["FITS_HOME"]
       end
 
+      initializer "ddr_antivirus" do
+        require "ddr-antivirus"
+        if Rails.env.test?
+          Ddr::Antivirus.test_mode!
+        else
+          Ddr::Antivirus.scanner_adapter = :clamd
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Engine initializer sets `Ddr::Antivirus.scanner_adapter` to `:clamd`
for development and production environments; test environment uses
`Ddr::Antivirus.test_mode!`.