### PR TITLE
Deprecated Ddr::Auth::GrouperGateway::REPOSITORY_GROUP_FILTER constant.

### DIFF
--- a/lib/ddr/auth.rb
+++ b/lib/ddr/auth.rb
@@ -102,5 +102,9 @@ module Ddr
       "::Ability"
     end
 
+    mattr_accessor :repository_group_filter do
+      ENV["REPOSITORY_GROUP_FILTER"]
+    end
+
   end
 end

--- a/lib/ddr/auth/grouper_gateway.rb
+++ b/lib/ddr/auth/grouper_gateway.rb
@@ -5,9 +5,17 @@ module Ddr
   module Auth
     class GrouperGateway < SimpleDelegator
 
-      REPOSITORY_GROUP_FILTER = "duke:library:repository:ddr:"
       SUBJECT_ID_RE = Regexp.new('[^@]+(?=@duke\.edu)')
       DEFAULT_TIMEOUT = 5
+
+      def self.const_missing(name)
+        if name == :REPOSITORY_GROUP_FILTER
+          warn "[DEPRECATION] The constant `#{name}` is deprecated and will be removed in ddr-models 3.0." \
+               " Use `Ddr::Auth.repository_group_filter` instead."
+          return Ddr::Auth.repository_group_filter
+        end
+        super
+      end
 
       def self.repository_groups(*args)
         new.repository_groups(*args)


### PR DESCRIPTION
Use Ddr::Auth.repository_group_filter instead.

Upgrade notes:
- Must set `REPOSITORY_GROUP_FILTER` environment variable if using `Ddr::Auth::GrouperGateway`.

Closes #281