### PR TITLE
Ddr::Auth.repository_group_filter returns ENV["REPOSITORY_GROUP_FILTER"]

### DIFF
--- a/lib/ddr/auth.rb
+++ b/lib/ddr/auth.rb
@@ -102,8 +102,11 @@ module Ddr
       "::Ability"
     end
 
-    mattr_accessor :repository_group_filter do
-      ENV["REPOSITORY_GROUP_FILTER"]
+    def self.repository_group_filter
+      if filter = ENV["REPOSITORY_GROUP_FILTER"]
+        return filter
+      end
+      raise Ddr::Models::Error, "The \"REPOSITORY_GROUP_FILTER\" environment variable is not set."
     end
 
   end

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.1.2"
+    VERSION = "2.1.3"
   end
 end


### PR DESCRIPTION
dynamically, rather than setting a statically set module variable.

Fixes #1450
Bumps version to 2.1.3