### PR TITLE
Fixes ability_spec

### DIFF
--- a/lib/ddr/auth/ability_definitions/datastream_ability_definitions.rb
+++ b/lib/ddr/auth/ability_definitions/datastream_ability_definitions.rb
@@ -11,7 +11,6 @@ module Ddr
         Ddr::Datastreams::CONTENT         => :download,
         Ddr::Datastreams::EXTRACTED_TEXT  => :download,
         Ddr::Datastreams::FITS            => :read,
-        Ddr::Datastreams::MULTIRES_IMAGE  => :read,
         Ddr::Datastreams::STRUCT_METADATA => :read,
         Ddr::Datastreams::THUMBNAIL       => :read,
       }.freeze

--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -52,6 +52,7 @@ module Ddr
     autoload :HasStructMetadata
     autoload :HasThumbnail
     autoload :Indexing
+    autoload :MultiresImage
     autoload :SolrDocument
     autoload :StructDiv
     autoload :Structure

--- a/lib/ddr/models/external_file.rb
+++ b/lib/ddr/models/external_file.rb
@@ -9,4 +9,3 @@ module Ddr::Models
 
   end
 end
-  

--- a/lib/ddr/models/has_multires_image.rb
+++ b/lib/ddr/models/has_multires_image.rb
@@ -3,12 +3,18 @@ module Ddr
     module HasMultiresImage
       extend ActiveSupport::Concern
 
-      included do
-        contains Ddr::Datastreams::MULTIRES_IMAGE
+      def multires_image
+        external_files.detect { |ef| ef.use.first == MultiresImage::USE }
+      end
+
+      def multires_image=(file_path)
+        self.external_files << MultiresImage.new(file_path)
       end
 
       def multires_image_file_path
-        URI.parse(datastreams[Ddr::Datastreams::MULTIRES_IMAGE].dsLocation).path if datastreams[Ddr::Datastreams::MULTIRES_IMAGE].dsLocation
+        if mri = multires_image
+          mri.file_path
+        end
       end
 
     end

--- a/lib/ddr/models/multires_image.rb
+++ b/lib/ddr/models/multires_image.rb
@@ -1,0 +1,21 @@
+require "uri"
+
+module Ddr::Models
+  class MultiresImage < ExternalFile
+
+    USE = "multires-image"
+
+    def initialize(file_path)
+      super.tap do |mri|
+        mri.location = "file:#{file_path}"
+        mri.use = USE
+        mri.mime_type = Ddr::Utils.mime_type_for(file_path)
+      end
+    end
+
+    def file_path
+      URI.parse(location.first).path
+    end
+
+  end
+end


### PR DESCRIPTION
@coblej Note that this introduces a MultiresImage object that encapsulates the creation of an MRI as an ExternalFile.  The reason the tests were broken had nothing to do with ability_spec as you can see, but with the multires_image_file_path method in HasMultiresImage.