### PR TITLE
Update deprecated `pid` to `id`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: ruby
 before_install:
   - sudo apt-get install libvips-dev
+  - gem install bundler --version "~> 1.10"
 rvm:
-  - 2.1
+  - 2.1.5
 script: "bundle exec rake ci"
 cache:
-  - bundler
   - apt
 notifications:
   email:
     - lib-drs@duke.edu
+bundler_args: --without production

--- a/lib/ddr/actions/fixity_check.rb
+++ b/lib/ddr/actions/fixity_check.rb
@@ -11,7 +11,7 @@ module Ddr
 
       # Return result of fixity check
       def self._execute(object)
-        Result.new(pid: object.pid).tap do |r|
+        Result.new(pid: object.id).tap do |r|
           object.datastreams_to_validate.each do |dsid, ds|
             r.success &&= ds.dsChecksumValid
             r.results[dsid] = ds.profile

--- a/lib/ddr/auth/ability_definitions/role_based_ability_definitions.rb
+++ b/lib/ddr/auth/ability_definitions/role_based_ability_definitions.rb
@@ -19,7 +19,7 @@ module Ddr
       def permissions(obj)
         case obj
         when Ddr::Models::Base, SolrDocument
-          cached_permissions obj.pid do
+          cached_permissions obj.id do
             obj.effective_permissions(agents)
           end
         when String

--- a/lib/ddr/datastreams/datastream_behavior.rb
+++ b/lib/ddr/datastreams/datastream_behavior.rb
@@ -1,83 +1,82 @@
-module Ddr
-  module Datastreams
-    module DatastreamBehavior
+module Ddr::Datastreams
+  module DatastreamBehavior
+    extend Deprecation
 
-      DEFAULT_FILE_EXTENSION = "bin"
-      STRFTIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%LZ"
+    DEFAULT_FILE_EXTENSION = "bin"
+    STRFTIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%LZ"
 
-      def dsid
-        warn "[DEPRECATION] `dsid` is no longer a datastream/file method." \
-             " Use `File.basename(id)`."
-        if id
-          ::File.basename(id)
-        end
+    def dsid
+      Deprecation.warn(DatastreamBehavior,
+                       "`dsid` is no longer a datastream/file method. Use `File.basename(id)`.")
+      if id
+        ::File.basename(id)
       end
-
-      def dsCreateDate
-        warn "[DEPRECATION] `dsCreateDate` is no longer a datastream/file method." \
-             " Use `create_date` instead."
-        create_date
-      end
-
-      def validate_checksum!(checksum_value, checksum_type=nil)
-        raise Ddr::Models::Error, "Checksum cannot be validated on new datastream." if new_record?
-        raise Ddr::Models::Error, "Checksum cannot be validated on unpersisted content." if content_changed?
-        raise Ddr::Models::ChecksumInvalid, "The repository internal checksum validation failed." unless check_fixity
-        algorithm = checksum_type || checksum.algorithm
-        calculated_checksum = if algorithm == checksum.algorithm
-                                checksum.value
-                              else
-                                content_digest(algorithm)
-                              end
-        if checksum_value == calculated_checksum
-          "The checksum #{algorithm}:#{checksum_value} is valid for datastream #{dsid}."
-        else
-          raise Ddr::Models::ChecksumInvalid, "The checksum #{algorithm}:#{checksum_value} is not valid for datastream #{dsid}."
-        end
-      end
-
-      def create_date_string
-        dsCreateDate.strftime(STRFTIME_FORMAT) if dsCreateDate
-      end
-
-      def content_digest(algorithm)
-        Ddr::Utils.digest(content, algorithm)
-      end
-
-      # Return default file extension for datastream based on MIME type
-      def default_file_extension
-        mimetypes = MIME::Types[mime_type]
-        return mimetypes.first.extensions.first unless mimetypes.empty?
-        case mime_type
-        when 'application/n-triples'
-          'txt'
-        else
-          DEFAULT_FILE_EXTENSION
-        end
-      end
-
-      def default_file_prefix
-        (id && id.gsub(/\//, "_")) || "NEW"
-      end
-
-      # Return default file name
-      def default_file_name
-        [ default_file_prefix, default_file_extension ].join(".")
-      end
-
-      def tempfile(prefix: nil, suffix: nil)
-        if empty?
-          raise Ddr::Models::Error, "Refusing to create tempfile for empty datastream!"
-        end
-        prefix ||= default_file_prefix + "--"
-        suffix ||= "." + default_file_extension
-        Tempfile.open [prefix, suffix], encoding: Encoding::ASCII_8BIT do |f|
-          f.write(content)
-          f.close
-          yield f
-        end
-      end
-
     end
+
+    def dsCreateDate
+      Deprecation.warn(DatastreamBehavior,
+                       "`dsCreateDate` is no longer a datastream/file method. Use `create_date` instead.")
+      create_date
+    end
+
+    def validate_checksum!(checksum_value, checksum_type=nil)
+      raise Ddr::Models::Error, "Checksum cannot be validated on new datastream." if new_record?
+      raise Ddr::Models::Error, "Checksum cannot be validated on unpersisted content." if content_changed?
+      raise Ddr::Models::ChecksumInvalid, "The repository internal checksum validation failed." unless check_fixity
+      algorithm = checksum_type || checksum.algorithm
+      calculated_checksum = if algorithm == checksum.algorithm
+                              checksum.value
+                            else
+                              content_digest(algorithm)
+                            end
+      if checksum_value == calculated_checksum
+        "The checksum #{algorithm}:#{checksum_value} is valid for datastream #{dsid}."
+      else
+        raise Ddr::Models::ChecksumInvalid, "The checksum #{algorithm}:#{checksum_value} is not valid for datastream #{dsid}."
+      end
+    end
+
+    def create_date_string
+      dsCreateDate.strftime(STRFTIME_FORMAT) if dsCreateDate
+    end
+
+    def content_digest(algorithm)
+      Ddr::Utils.digest(content, algorithm)
+    end
+
+    # Return default file extension for datastream based on MIME type
+    def default_file_extension
+      mimetypes = MIME::Types[mime_type]
+      return mimetypes.first.extensions.first unless mimetypes.empty?
+      case mime_type
+      when 'application/n-triples'
+        'txt'
+      else
+        DEFAULT_FILE_EXTENSION
+      end
+    end
+
+    def default_file_prefix
+      (id && id.gsub(/\//, "_")) || "NEW"
+    end
+
+    # Return default file name
+    def default_file_name
+      [ default_file_prefix, default_file_extension ].join(".")
+    end
+
+    def tempfile(prefix: nil, suffix: nil)
+      if empty?
+        raise Ddr::Models::Error, "Refusing to create tempfile for empty datastream!"
+      end
+      prefix ||= default_file_prefix + "--"
+      suffix ||= "." + default_file_extension
+      Tempfile.open [prefix, suffix], encoding: Encoding::ASCII_8BIT do |f|
+        f.write(content)
+        f.close
+        yield f
+      end
+    end
+
   end
 end

--- a/lib/ddr/events/event.rb
+++ b/lib/ddr/events/event.rb
@@ -45,7 +45,7 @@ module Ddr
       # Scopes
 
       def self.for_object(obj)
-        for_pid(obj.pid)
+        for_pid(obj.id)
       end
 
       def self.for_pid(pid)
@@ -92,7 +92,7 @@ module Ddr
 
       def object=(obj)
         raise ArgumentError, "Can't set to new object" if obj.new_record?
-        self.pid = obj.pid
+        self.pid = obj.id
         @object = obj
       end
 

--- a/lib/ddr/events/fixity_check_event.rb
+++ b/lib/ddr/events/fixity_check_event.rb
@@ -20,7 +20,7 @@ module Ddr
           validation = dsProfile["dsChecksumValid"] ? VALID : INVALID
           detail << DETAIL_TEMPLATE % {dsid: dsid, validation: validation}
         end
-        create(pid: result.pid,
+        create(pid: result.id,
                event_date_time: notification.time,
                outcome: result.success ? SUCCESS : FAILURE,
                detail: detail.join("\n")

--- a/lib/ddr/managers/derivatives_manager.rb
+++ b/lib/ddr/managers/derivatives_manager.rb
@@ -19,7 +19,7 @@ module Ddr
             # - object already has this derivative (need to delete or replace it)
             # - the derivative can be generated for this object
           if derivative.class.has_derivative?(object) || derivative.class.generatable?(object)
-            schedule == SCHEDULE_NOW ? update_derivative(derivative) : Resque.enqueue(DerivativeJob, object.pid, derivative_to_update)
+            schedule == SCHEDULE_NOW ? update_derivative(derivative) : Resque.enqueue(DerivativeJob, object.id, derivative_to_update)
           end
         end
       end
@@ -38,7 +38,7 @@ module Ddr
 
       def generate_derivative(derivative)
         ActiveSupport::Notifications.instrument(Ddr::Notifications::UPDATE,
-                                                pid: object.pid,
+                                                pid: object.id,
                                                 summary: "Generate #{derivative.class.name} derivative"
                                                 ) do |payload|
           derivative.generate!(object)
@@ -47,7 +47,7 @@ module Ddr
 
       def delete_derivative(derivative)
         ActiveSupport::Notifications.instrument(Ddr::Notifications::UPDATE,
-                                                pid: object.pid,
+                                                pid: object.id,
                                                 summary: "Delete derivative #{derivative.class.name}"
                                                 ) do |payload|
           derivative.delete!(object)

--- a/lib/ddr/managers/permanent_id_manager.rb
+++ b/lib/ddr/managers/permanent_id_manager.rb
@@ -21,13 +21,13 @@ module Ddr
       end
 
       def assign_later
-        Resque.enqueue(AssignmentJob, object.pid)
+        Resque.enqueue(AssignmentJob, object.id)
       end
 
       def assign
         raise Ddr::Models::Error, "Permanent ID already assigned." if object.permanent_id
         ActiveSupport::Notifications.instrument(Ddr::Notifications::UPDATE,
-                                                pid: object.pid,
+                                                pid: object.id,
                                                 software: SOFTWARE,
                                                 summary: ASSIGN_EVENT_SUMMARY
                                                 ) do |payload|

--- a/lib/ddr/models/governable.rb
+++ b/lib/ddr/models/governable.rb
@@ -36,7 +36,7 @@ module Ddr
         when other.has_admin_policy?
           other.admin_policy_id
         when other.is_a?(Collection)
-          other.pid
+          other.id
         end
         # self.admin_policy_id = other.admin_policy_id if other.has_admin_policy?
       end

--- a/lib/ddr/models/licenses/license.rb
+++ b/lib/ddr/models/licenses/license.rb
@@ -2,15 +2,21 @@ require "ddr_aux/client"
 
 module Ddr::Models
   class License < DdrAux::Client::License
+    extend Deprecation
 
-    attr_accessor :pid
+    attr_accessor :object_id
 
     def self.call(obj)
       if obj.license
         license = find(url: obj.license)
-        license.pid = obj.pid
+        license.object_id = obj.id
         license
       end
+    end
+
+    def pid
+      Deprecation.warn(License, "Use `object_id` instead.")
+      object_id
     end
 
     def to_s

--- a/lib/ddr/utils.rb
+++ b/lib/ddr/utils.rb
@@ -95,13 +95,13 @@ module Ddr::Utils
     objs = []
     ActiveFedora::Base.find_each( { Ddr::Index::Fields::IDENTIFIER_ALL => identifier }, { :cast => true } ) { |o| objs << o }
     pids = []
-    objs.each { |obj| pids << obj.pid }
+    objs.each { |obj| pids << obj.id }
     if model.present?
-      objs.each { |obj| pids.delete(obj.pid) unless obj.is_a?(model.constantize) }
+      objs.each { |obj| pids.delete(obj.id) unless obj.is_a?(model.constantize) }
     end
     if collection.present?
       objs.each do |obj|
-        pids.delete(obj.pid) unless obj == collection || obj.parent == collection
+        pids.delete(obj.id) unless obj == collection || obj.parent == collection
       end
     end
     case pids.size

--- a/spec/auth/ability_spec.rb
+++ b/spec/auth/ability_spec.rb
@@ -21,11 +21,11 @@ module Ddr::Auth
         describe "\"#{dsid}\"" do
           let(:ds) { obj.datastreams[dsid] }
           describe "can #{permission.inspect} object" do
-            before { subject.can permission, obj.pid }
+            before { subject.can permission, obj.id }
             it { should be_able_to(:download, ds) }
           end
           describe "cannot #{permission.inspect} object" do
-            before { subject.cannot permission, obj.pid }
+            before { subject.cannot permission, obj.id }
             it { should_not be_able_to(:download, ds) }
           end
         end
@@ -35,7 +35,7 @@ module Ddr::Auth
         (Component.ds_specs.keys.map(&:to_s) - DatastreamAbilityDefinitions::DATASTREAM_DOWNLOAD_ABILITIES.keys).each do |dsid|
           describe "\"#{dsid}\"" do
             let(:ds) { obj.datastreams[dsid] }
-            before { subject.can :download, obj.pid }
+            before { subject.can :download, obj.id }
             it { should_not be_able_to(:download, ds) }
           end
         end
@@ -175,23 +175,23 @@ module Ddr::Auth
       end
 
       describe "with a Ddr model instance" do
-        let(:obj) { Collection.new(pid: "test:1") }
-        let(:cache_key) { obj.pid }
+        let(:obj) { Collection.new(id: "test-1") }
+        let(:cache_key) { obj.id }
         let(:perm_obj) { obj }
         it_behaves_like "it has role based abilities"
       end
 
       describe "with a Solr document" do
-        let(:obj) { SolrDocument.new({"id"=>"test:1"}) }
-        let(:cache_key) { obj.pid }
+        let(:obj) { SolrDocument.new({"id"=>"test-1"}) }
+        let(:cache_key) { obj.id }
         let(:perm_obj) { obj }
         it_behaves_like "it has role based abilities"
       end
 
       describe "with a String" do
-        let(:obj) { "test:1" }
+        let(:obj) { "test-1" }
         let(:cache_key) { obj }
-        let(:perm_obj) { SolrDocument.new({"id"=>"test:1"}) }
+        let(:perm_obj) { SolrDocument.new({"id"=>"test-1"}) }
         before do
           allow_any_instance_of(RoleBasedAbilityDefinitions).to receive(:permissions_doc).with(obj) { perm_obj }
         end

--- a/spec/jobs/fits_file_characterization_spec.rb
+++ b/spec/jobs/fits_file_characterization_spec.rb
@@ -24,7 +24,7 @@ module Ddr::Jobs
         before do
           allow(Open3).to receive(:capture3) { [ stdout_msg, stderr_msg,  $? ] }
           allow_any_instance_of(Process::Status).to receive(:success?) { true }
-          Ddr::Jobs::FitsFileCharacterization.perform(object.pid)
+          Ddr::Jobs::FitsFileCharacterization.perform(object.id)
           object.reload
         end
         it "should populate the fits datastream" do
@@ -38,7 +38,7 @@ module Ddr::Jobs
         before do
           allow(Open3).to receive(:capture3) { [ stdout_msg, stderr_msg,  $? ] }
           allow_any_instance_of(Process::Status).to receive(:success?) { false }
-          Ddr::Jobs::FitsFileCharacterization.perform(object.pid)
+          Ddr::Jobs::FitsFileCharacterization.perform(object.id)
           object.reload
         end
         it "should not populate the fits datastream" do

--- a/spec/models/active_fedora_base_spec.rb
+++ b/spec/models/active_fedora_base_spec.rb
@@ -6,22 +6,22 @@ RSpec.describe ActiveFedora::Base do
     let!(:collection) { FactoryGirl.create(:collection) }
     describe "when called on the wrong class" do
       it "should raise an exception" do
-        expect { Item.find(collection.pid) }.to raise_error(ActiveFedora::ActiveFedoraError)
+        expect { Item.find(collection.id) }.to raise_error(ActiveFedora::ActiveFedoraError)
       end
     end
     describe "when called on Ddr::Models::Base" do
       it "should cast to the object's class" do
-        expect(Ddr::Models::Base.find(collection.pid)).to eq(collection)
+        expect(Ddr::Models::Base.find(collection.id)).to eq(collection)
       end
     end
     describe "when called on ActiveFedora::Base" do
       it "should cast to the object's class" do
-        expect(ActiveFedora::Base.find(collection.pid)).to eq(collection)
+        expect(ActiveFedora::Base.find(collection.id)).to eq(collection)
       end
     end
     describe "when called on the object's class" do
       it "should return the object" do
-        expect(Collection.find(collection.pid)).to eq(collection)
+        expect(Collection.find(collection.id)).to eq(collection)
       end
     end
   end

--- a/spec/models/active_fedora_datastream_spec.rb
+++ b/spec/models/active_fedora_datastream_spec.rb
@@ -65,20 +65,20 @@ module ActiveFedora
         context "the datstream is new" do
           before { allow(subject).to receive(:new_record?) { true } }
           it "should raise an exception" do
-            expect { subject.validate_checksum!(checksum, checksum_type) }.to raise_error
+            expect { subject.validate_checksum!("bb3200c2ddaee4bd7b9a4dc1ad3e10ed886eaef1") }.to raise_error(Ddr::Models::Error)
           end
         end
         context "the datastream content has changed" do
           before { allow(subject).to receive(:content_changed?) { true } }
           it "should raise an exception" do
-            expect { subject.validate_checksum!(checksum, checksum_type) }.to raise_error
+            expect { subject.validate_checksum!("bb3200c2ddaee4bd7b9a4dc1ad3e10ed886eaef1") }.to raise_error(Ddr::Models::Error)
           end
         end
       end
       context "with persisted content" do
         before do
           allow(subject).to receive(:new_record?) { false }
-          allow(subject).to receive(:pid) { "foobar:1" }
+          allow(subject).to receive(:pid) { "foobar-1" }
           allow(subject).to receive(:checksum) { checksum }
         end
         context "and the repository internal checksum in invalid" do
@@ -99,21 +99,19 @@ module ActiveFedora
           end
           context "and the checksum type is nil" do
             it "should compare the provided checksum with the datastream checksum" do
-              expect { subject.validate_checksum!(checksum.value) }
-                .not_to raise_error(Ddr::Models::Error)
+              expect { subject.validate_checksum!(checksum.value) }.not_to raise_error
             end
           end
           context "and the checksum type is the same as the datastream checksum type" do
             it "should compare the provided checksum with the datastream checksum" do
-              expect { subject.validate_checksum!(checksum.value, checksum.algorithm) }
-                .not_to raise_error(Ddr::Models::Error)
+              expect { subject.validate_checksum!(checksum.value, checksum.algorithm) }.not_to raise_error
             end
           end
           context "and the checksum type differs from the datastream checksum type" do
             let!(:md5digest) { "273ae0f4aa60d94e89bc0e0652ae2c8f" }
             it "should generate a checksum for comparison" do
               allow(subject).to receive(:content_digest).with("MD5") { md5digest }
-              expect { subject.validate_checksum!(md5digest, "MD5") }.not_to raise_error(Ddr::Models::Error)
+              expect { subject.validate_checksum!(md5digest, "MD5") }.not_to raise_error
             end
           end
           context "and the checksum doesn't match" do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Collection, type: :model do
       component = Component.create
       docs = subject.components_from_solr
       expect(docs.size).to eq(1)
-      expect(docs.first.id).to eq(component.pid)
+      expect(docs.first.id).to eq(component.id)
     end
   end
 

--- a/spec/models/effective_license_spec.rb
+++ b/spec/models/effective_license_spec.rb
@@ -8,7 +8,7 @@ module Ddr::Models
     let(:license) { License.new(url: url) }
     before { allow(License).to receive(:find).with(url: url) { license } }
 
-    let(:obj) { double(pid: "test:1", id: "test:1", license: nil, parent: nil, admin_policy: nil, admin_policy_id: nil) }
+    let(:obj) { double(id: "test-1", license: nil, parent: nil, admin_policy: nil, admin_policy_id: nil) }
 
     describe "when the object has a license" do
       before { allow(obj).to receive(:license) { url } }
@@ -17,7 +17,7 @@ module Ddr::Models
 
     describe "when the object does not have a license" do
       describe "and the object has a parent" do
-        let(:parent) { double(pid: "test:2", license: nil) }
+        let(:parent) { double(id: "test-2", license: nil) }
         before do
           allow(obj).to receive(:parent) { parent }
         end
@@ -33,11 +33,11 @@ module Ddr::Models
       end
       describe "and the object does not have a parent" do
         describe "and the object has an admin policy" do
-          let(:admin_policy) { double(pid: "test:3", id: "test:3", license: nil) }
+          let(:admin_policy) { double(id: "test-3", license: nil) }
           before { allow(obj).to receive(:admin_policy) { admin_policy } }
           describe "and the admin policy has a different id from the object" do
             before do
-              allow(obj).to receive(:admin_policy_id) { "test:3" }
+              allow(obj).to receive(:admin_policy_id) { "test-3" }
             end
             describe "and the admin policy has a license" do
               before do

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -6,16 +6,16 @@ module Ddr::Models
 
       describe "when the object has a license URL" do
         let(:url) { "http://example.com" }
-        let(:obj) { double(pid: "test:1", license: url) }
+        let(:obj) { double(id: "test-1", license: url) }
         before do
           allow(described_class).to receive(:find).with(url: url) { described_class.new(url: url, title: "A License") }
         end
-        its(:pid) { is_expected.to eq("test:1") }
+        its(:pid) { is_expected.to eq("test-1") }
         its(:to_s) { is_expected.to eq("A License") }
       end
 
       describe "when the object does not have a license" do
-        let(:obj) { double(pid: "test:1", license: nil) }
+        let(:obj) { double(id: "test-1", license: nil) }
         it { is_expected.to be_nil }
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,22 +9,23 @@ require "rails"
 require "rspec/rails"
 require "rspec/its"
 require "factory_girl_rails"
-require "database_cleaner"
 require "tempfile"
-require "resque"
 require "cancan/matchers"
 require 'equivalent-xml/rspec_matchers'
+require 'active_fedora/cleaner'
 
+require "resque"
 Resque.inline = true
 
 OmniAuth.config.test_mode = true
 
 Dir[File.join(File.dirname(__FILE__), "support", "*.rb")].each { |f| require f }
 
+require "database_cleaner"
 DatabaseCleaner.strategy = :truncation
 
 # Silence deprecation warnings
-warn "Default deprecation behavior set to :silence!"
+warn "WARNING: Default deprecation behavior set to :silence!"
 Deprecation.default_deprecation_behavior = :silence
 
 RSpec.configure do |config|
@@ -105,7 +106,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     DatabaseCleaner.clean
-    ActiveFedora::Base.destroy_all
+    ActiveFedora::Cleaner.clean!
     Ddr::Derivatives.configure do |config|
       config.update_derivatives = [ :multires_image, :thumbnail ]
     end
@@ -127,7 +128,7 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
-    ActiveFedora::Base.destroy_all
+    ActiveFedora::Cleaner.clean!
   end
 
 end

--- a/spec/support/shared_examples_for_events.rb
+++ b/spec/support/shared_examples_for_events.rb
@@ -82,7 +82,7 @@ RSpec.shared_examples "an event" do
     end
     context "when attributes are set" do
       let(:obj) { ActiveFedora::Base.create }
-      let(:event) { described_class.new(pid: obj.pid, outcome: Ddr::Events::Event::FAILURE, event_date_time: Time.utc(2013), software: "Test", summary: "A terrible disaster") }
+      let(:event) { described_class.new(pid: obj.id, outcome: Ddr::Events::Event::FAILURE, event_date_time: Time.utc(2013), software: "Test", summary: "A terrible disaster") }
       it "should not overwrite attributes" do
         expect { event.send(:set_defaults) }.not_to change { event.outcome }
         expect { event.send(:set_defaults) }.not_to change { event.event_date_time }
@@ -93,25 +93,25 @@ RSpec.shared_examples "an event" do
   end
 
   describe "object getter" do
-    subject { described_class.new(pid: "test:123") }
+    subject { described_class.new(pid: "test-123") }
     let(:object) { mock_object }
-    before { allow(ActiveFedora::Base).to receive(:find).with("test:123") { object } }
+    before { allow(ActiveFedora::Base).to receive(:find).with("test-123") { object } }
     it "should retrieve the object" do
       expect(subject.object).to eq object
     end
     it "should cache the object" do
-      expect(ActiveFedora::Base).to receive(:find).with("test:123").once
+      expect(ActiveFedora::Base).to receive(:find).with("test-123").once
       subject.object
       subject.object
     end
   end
 
   describe "object setter" do
-    let(:object) { mock_object(pid: "test:123") }
+    let(:object) { mock_object(id: "test-123") }
     it "should set the event pid and object" do
       allow(object).to receive(:new_record?) { false }
       subject.object = object
-      expect(subject.pid).to eq "test:123"
+      expect(subject.pid).to eq "test-123"
       expect(subject.object).to eq object
     end
     it "should raise an ArgumentError if object is a new record" do

--- a/spec/support/shared_examples_for_governables.rb
+++ b/spec/support/shared_examples_for_governables.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples "a governable object" do
     it "should set its admin policy with #admin_policy= and get with #admin_policy" do
       object.admin_policy = coll
       object.save(validate: false)
-      expect(ActiveFedora::Base.find(object.pid).admin_policy).to eq(coll)
+      expect(ActiveFedora::Base.find(object.id).admin_policy).to eq(coll)
     end
   end
 end


### PR DESCRIPTION
Fixed some warnings.
Use Deprecation library for deprecations.
Remove bundler caching for Travis CI.