### PR TITLE
Removes dependency on hydra-head gem.

### DIFF
--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 4.1.13"
   s.add_dependency "active-triples", "~> 0.7.2"
   s.add_dependency "active-fedora", "~> 9.5"
-  s.add_dependency "hydra-core", "~> 9.3"
   s.add_dependency "hydra-validations", "~> 0.5"
   s.add_dependency "devise", "~> 3.4"
   s.add_dependency "omniauth-shibboleth", "~> 1.2.0"
@@ -42,4 +41,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "factory_girl_rails", "~> 4.4"
   s.add_development_dependency "jettywrapper", "~> 2.0"
   s.add_development_dependency "database_cleaner"
+  s.add_development_dependency "blacklight", "~> 5.15"
 end

--- a/lib/ddr/auth/abstract_ability.rb
+++ b/lib/ddr/auth/abstract_ability.rb
@@ -1,3 +1,5 @@
+require 'cancancan'
+
 module Ddr::Auth
   # @abstract
   class AbstractAbility

--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -1,12 +1,8 @@
 require 'ddr/models/engine'
 require 'ddr/models/version'
 
-# Awful hack to make Hydra::AccessControls::Permissions accessible
-# $: << Gem.loaded_specs['hydra-access-controls'].full_gem_path + "/app/models/concerns"
-
 require 'active_record'
-
-require 'hydra-core'
+require 'active_fedora'
 require 'hydra/validations'
 
 module Ddr

--- a/spec/controllers/including_role_based_access_controls_enforcement_spec.rb
+++ b/spec/controllers/including_role_based_access_controls_enforcement_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe ApplicationController, type: :controller do
 
   controller do
-    include Hydra::AccessControlsEnforcement
     include Ddr::Auth::RoleBasedAccessControlsEnforcement
   end
 

--- a/spec/dummy/app/models/solr_document.rb
+++ b/spec/dummy/app/models/solr_document.rb
@@ -1,7 +1,5 @@
-# -*- encoding : utf-8 -*-
-#
-# A SolrDocument is a wrapper of a raw Solr document result.
-#
+require 'blacklight'
+
 class SolrDocument
   include Blacklight::Solr::Document
   include Ddr::Models::SolrDocument

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,4 +1,3 @@
 class User < ActiveRecord::Base
   include Ddr::Auth::User
-  include Blacklight::User
 end


### PR DESCRIPTION
Blacklight is a development dependency, mainly for SolrDocument.