### PR TITLE
Adds Ddr::Jobs::Job module for extending Resque job classes.

### DIFF
--- a/lib/ddr/jobs.rb
+++ b/lib/ddr/jobs.rb
@@ -2,8 +2,10 @@ module Ddr
   module Jobs
     extend ActiveSupport::Autoload
 
-    autoload :PermanentId
     autoload :FitsFileCharacterization
+    autoload :Job
+    autoload :PermanentId
+    autoload :Queue
 
     autoload_at 'ddr/jobs/permanent_id' do
       autoload :MakeUnavailable

--- a/lib/ddr/jobs/fits_file_characterization.rb
+++ b/lib/ddr/jobs/fits_file_characterization.rb
@@ -2,6 +2,7 @@ require 'open3'
 
 module Ddr::Jobs
   class FitsFileCharacterization
+    extend Job
 
     @queue = :file_characterization
 

--- a/lib/ddr/jobs/job.rb
+++ b/lib/ddr/jobs/job.rb
@@ -1,0 +1,26 @@
+require "resque"
+
+module Ddr::Jobs
+  module Job
+
+    def self.extended(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      # @return [Array<String>] list of object ids queued for this job type.
+      # @note Assumes that the object_id is the first argument of the .perform method.
+      def queued_object_ids(**args)
+        args[:type] = self
+        __queue__.jobs(**args).map { |job| job["args"].first }
+      end
+
+      private
+
+      def __queue__
+        @__queue__ = Queue.new(Resque.queue_from_class(self))
+      end
+    end
+
+  end
+end

--- a/lib/ddr/jobs/queue.rb
+++ b/lib/ddr/jobs/queue.rb
@@ -1,0 +1,27 @@
+require "resque"
+
+module Ddr::Jobs
+  class Queue
+
+    attr_reader :name
+
+    def initialize(name)
+      @name = name
+    end
+
+    def size
+      Resque.size(name)
+    end
+
+    # @return [Array<Hash>] jobs in the queue, optionally filtered by type,
+    #   start position, and count.
+    def jobs(type: nil, start: 0, count: nil)
+      jobs = Resque.peek(name, start, count || size)
+      if type
+        jobs.select! { |job| job["class"] == type.to_s }
+      end
+      jobs
+    end
+
+  end
+end

--- a/spec/jobs/job_spec.rb
+++ b/spec/jobs/job_spec.rb
@@ -1,0 +1,40 @@
+module Ddr::Jobs
+  RSpec.describe Job do
+
+    before(:all) do
+      class TestJob
+        extend Job
+
+        @queue = :test
+
+        def perform(object_id)
+          puts object_id
+        end
+      end
+    end
+
+    after(:all) do
+      Ddr::Jobs.send(:remove_const, :TestJob)
+    end
+
+    let(:queued) do
+      [{"class"=>"Ddr::Jobs::TestJob", "args"=>["test-1"]},
+       {"class"=>"Ddr::Jobs::OtherJob", "args"=>["test-2"]},
+       {"class"=>"Ddr::Jobs::TestJob", "args"=>["test-3"]},
+      ]
+    end
+
+    before(:each) do
+      allow(Resque).to receive(:size).with(:test) { 3 }
+      allow(Resque).to receive(:peek).with(:test, 0, 3) { queued }
+    end
+
+    describe ".queued_object_ids" do
+      it "returns the list of object_ids for queued jobs of this type" do
+        expect(TestJob.queued_object_ids)
+          .to contain_exactly("test-1", "test-3")
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Adds Ddr::Jobs::Queue class to wrap Resque queue info methods.
Extends FitsFileCharacterization job with new module.