### PR TITLE
Added `tempdir` config setting to Ddr::Models

### DIFF
--- a/lib/ddr/jobs/fits_file_characterization.rb
+++ b/lib/ddr/jobs/fits_file_characterization.rb
@@ -10,7 +10,7 @@ module Ddr::Jobs
     def self.perform(pid)
       obj = ActiveFedora::Base.find(pid)
       tmp_filename = Ddr::Utils::sanitize_filename(obj.original_filename) || obj.content.default_file_name
-      Dir.mktmpdir do |dir|
+      Dir.mktmpdir(nil, Ddr::Models.tempdir) do |dir|
         infile = create_temp_infile(dir, tmp_filename, obj.content.content)
         fits_output, err, status = Open3.capture3(fits_command, '-i', infile)
         if status.success? && fits_output.present?

--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -98,6 +98,11 @@ module Ddr
       "http://library.duke.edu/rubenstein/findingaids/"
     end
 
+    # Application temp dir - defaults to system temp dir
+    mattr_accessor :tempdir do
+      Dir.tmpdir
+    end
+
     # Yields an object with module configuration accessors
     def self.configure
       yield self

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.3.1"
+    VERSION = "2.3.2"
   end
 end


### PR DESCRIPTION
Ddr::Jobs::FitsFileCharacterization jobs uses new tempdir setting.
Version 2.3.2