### PR TITLE
Modifications to Ddr::Jobs::FitsFileCharacterization job.

### DIFF
--- a/lib/ddr/jobs/fits_file_characterization.rb
+++ b/lib/ddr/jobs/fits_file_characterization.rb
@@ -1,51 +1,12 @@
-require 'open3'
-
 module Ddr::Jobs
   class FitsFileCharacterization
     extend Job
 
     @queue = :file_characterization
 
-    EVENT_SUMMARY = 'FITS characterization of content file'.freeze
-
     def self.perform(pid)
       obj = ActiveFedora::Base.find(pid)
-      tmp_filename = Ddr::Utils::sanitize_filename(obj.original_filename) || obj.content.default_file_name
-      Dir.mktmpdir(nil, Ddr::Models.tempdir) do |dir|
-        infile = create_temp_infile(dir, tmp_filename, obj.content.content)
-        fits_output, err, status = Open3.capture3(fits_command, '-i', infile)
-        if status.success? && fits_output.present?
-          obj.reload
-          obj.fits.content = fits_output
-          obj.save!
-        end
-        notify_event(pid, err, status)
-      end
-    end
-
-    def self.fits_command
-      File.join(Ddr::Models.fits_home, 'fits.sh')
-    end
-
-    def self.fits_version
-      `#{fits_command} -v`.strip
-    end
-
-    private
-
-    def self.create_temp_infile(dir, tmp_filename, content)
-      temp_infile = File.join(dir, tmp_filename)
-      File.open(temp_infile, 'wb') do |f|
-        f.write content
-      end
-      temp_infile
-    end
-
-    def self.notify_event(pid, err, status)
-      details = status.success? ? nil : err
-      event_args = { pid: pid, summary: EVENT_SUMMARY, software:  "fits #{fits_version}", detail: details }
-      event_args[:outcome] = status.success? ? Ddr::Events::Event::SUCCESS : Ddr::Events::Event::FAILURE
-      Ddr::Notifications.notify_event(:update, event_args)
+      Ddr::Models::FileCharacterization.call(obj)
     end
 
   end

--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -39,6 +39,7 @@ module Ddr
     autoload :Describable
     autoload :Error
     autoload :EventLoggable
+    autoload :FileCharacterization
     autoload :FileManagement
     autoload :FindingAid
     autoload :FixityCheckable
@@ -54,6 +55,7 @@ module Ddr
     autoload :SolrDocument
     autoload :StructDiv
     autoload :Structure
+    autoload :WithContentFile
     autoload :YearFacet
 
     autoload_under "licenses" do

--- a/lib/ddr/models/file_characterization.rb
+++ b/lib/ddr/models/file_characterization.rb
@@ -1,0 +1,37 @@
+require "delegate"
+require "shellwords"
+
+module Ddr::Models
+  class FileCharacterization < SimpleDelegator
+
+    class FITSError < Error; end
+
+    def self.call(obj)
+      new(obj).call
+    end
+
+    def call
+      with_content_file do |path|
+        fits_output = run_fits(path)
+        reload
+        fits.content = fits_output
+        save!
+      end
+    end
+
+    private
+
+    def run_fits(path)
+      output = `#{fits_command} -i #{Shellwords.escape(path)}`
+      unless $?.success?
+        raise FITSError, output
+      end
+      output
+    end
+
+    def fits_command
+      File.join(Ddr::Models.fits_home, 'fits.sh')
+    end
+
+  end
+end

--- a/lib/ddr/models/has_content.rb
+++ b/lib/ddr/models/has_content.rb
@@ -1,5 +1,3 @@
-require 'openssl'
-
 module Ddr
   module Models
     module HasContent
@@ -126,6 +124,10 @@ module Ddr
 
       def has_extracted_text?
         extractedText.has_content?
+      end
+
+      def with_content_file(&block)
+        WithContentFile.new(self, &block)
       end
 
       protected

--- a/lib/ddr/models/with_content_file.rb
+++ b/lib/ddr/models/with_content_file.rb
@@ -1,0 +1,37 @@
+require "tempfile"
+require "delegate"
+
+module Ddr::Models
+  class WithContentFile < SimpleDelegator
+
+    def initialize(obj, &block)
+      super(obj)
+      with_temp_file &block
+    end
+
+    # Yields path of tempfile containing content to block
+    # @yield [String] the path to the tempfile containing content
+    def with_temp_file
+      filename = original_filename || content.default_file_name
+      basename = [ File.basename(filename, ".*"), File.extname(filename) ]
+      infile = Tempfile.open(basename, Ddr::Models.tempdir, encoding: 'ascii-8bit')
+      begin
+        infile.write(content.content)
+        infile.close
+        verify_checksum!(infile)
+        yield infile.path
+      ensure
+        infile.close unless infile.closed?
+        File.unlink(infile)
+      end
+    end
+
+    def verify_checksum!(file)
+      digest = Ddr::Utils.digest(File.read(file), content.checksumType)
+      if digest != content.checksum
+        raise ChecksumInvalid, "The checksum of the downloaded file does not match the stored checksum of the content."
+      end
+    end
+
+  end
+end

--- a/spec/jobs/fits_file_characterization_spec.rb
+++ b/spec/jobs/fits_file_characterization_spec.rb
@@ -3,50 +3,14 @@ require 'spec_helper'
 module Ddr::Jobs
   RSpec.describe FitsFileCharacterization, jobs: true, file_characterization: true do
 
-    shared_examples "has a fits update event" do
-      let(:event) { object.update_events.last }
-      it "should have the correct event attributes" do
-        expect(event.outcome).to eq(expected_outcome)
-        expect(event.detail).to eq(expected_detail)
-        expect(event.software).to eq("fits #{fits_version}")
-      end
-    end
+    let(:obj) { double }
 
-    context "content-bearing object" do
-      let(:object) { TestContent.create }
-      let(:stdout_msg) { '<fits />' }
-      let(:stderr_msg) { 'stderr msg' }
-      let(:fits_version) { '0.9.9 '}
-      before { allow(Ddr::Jobs::FitsFileCharacterization).to receive(:fits_version) { fits_version } }
-      context "fits command is successful" do
-        let(:expected_outcome) { Ddr::Events::Event::SUCCESS }
-        let(:expected_detail) { nil }
-        before do
-          allow(Open3).to receive(:capture3) { [ stdout_msg, stderr_msg,  $? ] }
-          allow_any_instance_of(Process::Status).to receive(:success?) { true }
-          Ddr::Jobs::FitsFileCharacterization.perform(object.pid)
-          object.reload
-        end
-        it "should populate the fits datastream" do
-          expect(object.fits.content).to be_present
-        end
-        it_behaves_like "has a fits update event"
-      end
-      context "fits command is not successful" do
-        let(:expected_outcome) { Ddr::Events::Event::FAILURE }
-        let(:expected_detail) { stderr_msg }
-        before do
-          allow(Open3).to receive(:capture3) { [ stdout_msg, stderr_msg,  $? ] }
-          allow_any_instance_of(Process::Status).to receive(:success?) { false }
-          Ddr::Jobs::FitsFileCharacterization.perform(object.pid)
-          object.reload
-        end
-        it "should not populate the fits datastream" do
-          expect(object.fits.content).to_not be_present
-        end
-        it_behaves_like "has a fits update event"
-      end
-    end
+    before { allow(ActiveFedora::Base).to receive(:find).with("test:1") { obj } }
+
+    specify {
+      expect(Ddr::Models::FileCharacterization).to receive(:call).with(obj) { nil }
+      described_class.perform("test:1")
+    }
 
   end
 end

--- a/spec/models/file_characterization_spec.rb
+++ b/spec/models/file_characterization_spec.rb
@@ -1,0 +1,39 @@
+module Ddr::Models
+  RSpec.describe FileCharacterization do
+
+    subject { described_class.new(obj) }
+
+    before {
+      obj.content.checksumType = "SHA-1"
+      obj.save!
+    }
+
+    let(:obj) { FactoryGirl.create(:component) }
+    let(:fits_output) { "<fits/>" }
+
+    describe "when there is an error running FITS" do
+      before {
+        allow(subject).to receive(:run_fits).and_raise(FileCharacterization::FITSError)
+      }
+      specify {
+        begin
+          subject.call
+        rescue FileCharacterization::FITSError
+        ensure
+          expect(subject.fits).not_to have_content
+        end
+      }
+    end
+
+    describe "when FITS runs successfully" do
+      before {
+        allow(subject).to receive(:run_fits) { fits_output }
+      }
+      specify {
+        subject.call
+        expect(subject.fits.content).to eq(fits_output)
+      }
+    end
+
+  end
+end

--- a/spec/models/with_content_file_spec.rb
+++ b/spec/models/with_content_file_spec.rb
@@ -1,0 +1,37 @@
+module Ddr::Models
+  RSpec.describe WithContentFile do
+
+    let(:obj) { FactoryGirl.create(:component) }
+
+    before {
+      obj.content.checksumType = "SHA-1"
+      obj.save!
+    }
+
+    it "yields a temp file path to the block and deletes the temp file afterwards" do
+      WithContentFile.new(obj) do |path|
+        @path = path
+        expect(File.exist?(path)).to be true
+      end
+      expect(File.exist?(@path)).to be false
+    end
+
+    it "deletes the temp file even when an exception is raised in the block" do
+      begin
+        WithContentFile.new(obj) do |path|
+          @path = path
+          expect(File.exist?(path)).to be true
+          raise Error, "error"
+        end
+      rescue Error
+        expect(File.exist?(@path)).to be false
+      end
+    end
+
+    it "raises an exception when the checksum verification fails" do
+      allow(obj.content).to receive(:checksum) { "foo" }
+      expect { WithContentFile.new(obj) { |p| nil } }.to raise_error(ChecksumInvalid)
+    end
+
+  end
+end


### PR DESCRIPTION
Business logic extracted out to Ddr::Models::FileCharacterization.
Verifies checksum of tempfile (closes #488).
Use backticks for external command execution, replacing Open3 (closes #468).
No longer generates an update event.