### PR TITLE
Adds fcrepo3_pid single-valued property to admin metadata for Fcrepo3…

### DIFF
--- a/lib/ddr/index/fields.rb
+++ b/lib/ddr/index/fields.rb
@@ -40,6 +40,7 @@ module Ddr::Index
     DOI                         = Field.new :doi, :symbol
     EAD_ID                      = Field.new :ead_id, :stored_sortable
     EXTRACTED_TEXT              = Field.new :extracted_text, :searchable, type: :text
+    FCREPO3_PID                 = Field.new :fcrepo3_pid, :stored_sortable
     HAS_MODEL                   = Field.new :has_model, :symbol
     IDENTIFIER_ALL              = Field.new :identifier_all, :symbol
     IS_ATTACHED_TO              = Field.new :is_attached_to, :symbol

--- a/lib/ddr/models/has_admin_metadata.rb
+++ b/lib/ddr/models/has_admin_metadata.rb
@@ -29,6 +29,10 @@ module Ddr::Models
                predicate: Ddr::Vocab::Asset.eadId,
                multiple: false
 
+      property :fcrepo3_pid,
+               predicate: RDF::URI("info:fedora/fedora-system:def/model#PID"),
+               multiple: false
+
       property :license,
                predicate: RDF::DC.license,
                multiple: false

--- a/lib/ddr/models/indexing.rb
+++ b/lib/ddr/models/indexing.rb
@@ -22,6 +22,7 @@ module Ddr
           DISPLAY_FORMAT        => display_format,
           DOI                   => doi,
           EAD_ID                => ead_id,
+          FCREPO3_PID           => fcrepo3_pid,
           IDENTIFIER_ALL        => all_identifiers,
           LICENSE               => license,
           LOCAL_ID              => local_id,

--- a/spec/models/indexing_spec.rb
+++ b/spec/models/indexing_spec.rb
@@ -18,6 +18,7 @@ module Ddr::Models
       obj.permanent_url = "http://id.library.duke.edu/ark:/99999/fk4zzz"
       obj.display_format = "Image"
       obj.roles.grant role1, role2, role3, role4
+      obj.fcrepo3_pid = "duke:1"
     end
 
     its([Indexing::LICENSE]) { is_expected.to eq("cc-by-nc-nd-40") }
@@ -29,6 +30,6 @@ module Ddr::Models
     its([Indexing::ACCESS_ROLE]) { is_expected.to eq(obj.roles.to_json) }
     its([Indexing::POLICY_ROLE]) { is_expected.to contain_exactly(role2.agent, role3.agent, role4.agent) }
     its([Indexing::RESOURCE_ROLE]) { is_expected.to contain_exactly(role1.agent) }
-
+    its([Indexing::FCREPO3_PID]) { is_expected.to eq("duke:1") }
   end
 end


### PR DESCRIPTION
… PID.

Note the predicate used is documented at https://github.com/fcrepo4-exts/migration-utils,
but as of this commit has not been added to the ActiveFedora::RDF::Fcrepo::Model vocab.