### PR TITLE
Adds Ddr::Index::Fields.descmd

### DIFF
--- a/lib/ddr/index/fields.rb
+++ b/lib/ddr/index/fields.rb
@@ -2,16 +2,6 @@ module Ddr::Index
   module Fields
     extend Deprecation
 
-    def self.get(name)
-      const_get(name.to_s.upcase, false)
-    end
-
-    def self.techmd
-      constants(false)
-        .select { |c| c =~ /\ATECHMD_/ }
-        .map    { |c| const_get(c) }
-    end
-
     ID = UniqueKeyField.instance
 
     ACCESS_ROLE                 = Field.new :access_role, :stored_sortable
@@ -84,6 +74,20 @@ module Ddr::Index
     TYPE_FACET                  = Field.new :type_facet, :facetable
     WORKFLOW_STATE              = Field.new :workflow_state, :stored_sortable
     YEAR_FACET                  = Field.new :year_facet, solr_name: "year_facet_iim"
+
+    def self.get(name)
+      const_get(name.to_s.upcase, false)
+    end
+
+    def self.techmd
+      @techmd ||= constants(false).select { |c| c =~ /\ATECHMD_/ }.map { |c| const_get(c) }
+    end
+
+    def self.descmd
+      @descmd ||= Ddr::Datastreams::DescriptiveMetadataDatastream.properties.map do |base, config|
+        Field.new base, *(config.behaviors)
+      end
+    end
 
     def self.const_missing(name)
       if name == :PID

--- a/spec/index/fields_spec.rb
+++ b/spec/index/fields_spec.rb
@@ -1,6 +1,28 @@
 module Ddr::Index
   RSpec.describe Fields do
 
+    describe "module methods" do
+      specify {
+        expect(Fields.techmd).to contain_exactly(
+                                   Fields::TECHMD_COLOR_SPACE,
+                                   Fields::TECHMD_CREATING_APPLICATION,
+                                   Fields::TECHMD_CREATION_TIME,
+                                   Fields::TECHMD_FILE_SIZE,
+                                   Fields::TECHMD_FITS_VERSION,
+                                   Fields::TECHMD_FITS_DATETIME,
+                                   Fields::TECHMD_FORMAT_LABEL,
+                                   Fields::TECHMD_FORMAT_VERSION,
+                                   Fields::TECHMD_IMAGE_HEIGHT,
+                                   Fields::TECHMD_IMAGE_WIDTH,
+                                   Fields::TECHMD_MEDIA_TYPE,
+                                   Fields::TECHMD_MODIFICATION_TIME,
+                                   Fields::TECHMD_PRONOM_IDENTIFIER,
+                                   Fields::TECHMD_VALID,
+                                   Fields::TECHMD_WELL_FORMED
+                                 )
+      }
+    end
+
     describe "constants" do
       describe "ID" do
         subject { Fields::ID }


### PR DESCRIPTION
Returns an array of Field instances for all descriptive metadata fields.