### PR TITLE
Ddr::Index::Query accepts block in initializer.

### DIFF
--- a/lib/ddr/index/field_attribute.rb
+++ b/lib/ddr/index/field_attribute.rb
@@ -3,7 +3,7 @@ require "virtus"
 module Ddr::Index
   class FieldAttribute < Virtus::Attribute
 
-    def coerce(value)
+    def self.coerce(value)
       case value
       when Field
         value
@@ -12,6 +12,10 @@ module Ddr::Index
       when Symbol
         Fields.get(value)
       end
+    end
+
+    def coerce(value)
+      self.class.coerce(value)
     end
 
   end

--- a/lib/ddr/index/filter.rb
+++ b/lib/ddr/index/filter.rb
@@ -27,6 +27,12 @@ module Ddr::Index
         self
       end
 
+      def where_not(conditions)
+        self.clauses += conditions.map do |field, v|
+          Array(v).map { |value| QueryClause.negative(field, value) }
+        end.flatten
+      end
+
       def absent(field)
         self.clauses << QueryClause.absent(field)
         self
@@ -59,7 +65,7 @@ module Ddr::Index
       delegate Api.public_instance_methods => :new_filter
 
       def has_content
-        where active_fedora_model: [ "Component", "Attachment", "Target" ]
+        model "Component", "Attachment", "Target"
       end
 
       def is_governed_by(object_or_id)
@@ -68,6 +74,10 @@ module Ddr::Index
 
       def is_member_of_collection(object_or_id)
         term is_member_of_collection: internal_uri(object_or_id)
+      end
+
+      def model(*models)
+        where active_fedora_model: models
       end
 
       private

--- a/lib/ddr/index/query.rb
+++ b/lib/ddr/index/query.rb
@@ -15,6 +15,13 @@ module Ddr::Index
     delegate [:count, :docs, :pids, :each_pid, :all] => :result
     delegate :params => :query_params
 
+    def initialize(**args, &block)
+      super(**args)
+      if block_given?
+        build(&block)
+      end
+    end
+
     def inspect
       "#<#{self.class.name} q=#{q.inspect}, filters=#{filters.inspect}," \
       " sort=#{sort.inspect}, rows=#{rows.inspect}, fields=#{fields.inspect}>"
@@ -38,6 +45,11 @@ module Ddr::Index
 
     def query_params
       QueryParams.new(self)
+    end
+
+    def build(&block)
+      QueryBuilder.new(self, &block)
+      self
     end
 
   end

--- a/lib/ddr/index/query_builder.rb
+++ b/lib/ddr/index/query_builder.rb
@@ -12,6 +12,7 @@ module Ddr::Index
   #
   # asc [field], ...
   #   Adds ascending orderings by the fields specified.
+  #
   #   See also: desc, order_by
   #
   # before [field], [date_time]
@@ -20,10 +21,11 @@ module Ddr::Index
   #
   # before_days [field], [int]
   #   Adds a filter selecting documents where the field has a date/time the
-  #   specified number of days before today (now) or earlier.
+  #     specified number of days before today (now) or earlier.
   #
   # desc [field], ...
   #   Adds descending orderings by the fields specified.
+  #
   #   See also: asc, order_by
   #
   # id [doc_id]
@@ -31,6 +33,7 @@ module Ddr::Index
   #
   # filter [filter1], ...
   #   Adds filters to the query.
+  #
   #   Aliased as: filters
   #
   # filters [filter], ...
@@ -38,7 +41,8 @@ module Ddr::Index
   #
   # field [field1], ...
   #   Adds fields to result documents.
-  #   Note that all fields are returned when none is specified.
+  #     Note that all fields are returned when none is specified.
+  #
   #   Aliased as: fields
   #
   # fields [field], ...
@@ -46,13 +50,19 @@ module Ddr::Index
   #
   # limit [int]
   #   Limits the number of documents returned by the query.
+  #
   #   Aliased as: rows
+  #
+  # model [model_name], ...
+  #   Adds a filter selecting document where ActiveFedora model equals value
+  #     or one of the values.
   #
   # negative [field], [value]
   #   Adds a filter selecting document where field does not have the value.
   #
   # order_by [{field => order, ...}], ...
   #   Adds ordering(s) to the query.
+  #
   #   Aliased as: sort
   #
   # present [field]
@@ -75,8 +85,8 @@ module Ddr::Index
   #
   # where [{field => value, ...}]
   #   Adds a filter of "standard" query clauses.
-  #   Values will be escaped when the filter is serialized.
-  #   If a hash value is an array, that query clause will select documents
+  #     Values will be escaped when the filter is serialized.
+  #     If a hash value is an array, that query clause will select documents
   #     where the field matches any array entry.
   #
   class QueryBuilder
@@ -95,8 +105,8 @@ module Ddr::Index
 
     attr_reader :query
 
-    def initialize(&block)
-      @query = Query.new
+    def initialize(query = nil, &block)
+      @query = query || Query.new
       if block_given?
         instance_eval &block
       end
@@ -120,7 +130,7 @@ module Ddr::Index
     # @param fields [Array<Field>]
     # @return [QueryBuilder] self
     def field(*fields)
-      query.fields += fields
+      query.fields += fields.flatten.map { |f| FieldAttribute.coerce(f) }
       self
     end
     alias_method :fields, :field

--- a/lib/ddr/index/query_clause.rb
+++ b/lib/ddr/index/query_clause.rb
@@ -46,10 +46,11 @@ module Ddr::Index
       alias_method :id, :unique_key
 
       def where(field, value)
-        if value.respond_to?(:each)
-          disjunction(field, value)
+         values = Array(value)
+        if values.size > 1
+          disjunction(field, values)
         else
-          new(field: field, value: value, quote_value: true)
+          new(field: field, value: values.first, quote_value: true)
         end
       end
 
@@ -65,7 +66,7 @@ module Ddr::Index
 
       # Builds a query clause to filter where field is NOT present (no values)
       def absent(field)
-        new(field: "-#{field}", value: ANY_VALUE)
+        new(field: field, value: ANY_VALUE, template: NEGATIVE_QUERY)
       end
 
       # Builds a query clause to filter where field contains at least one of a set of values.

--- a/spec/index/filter_spec.rb
+++ b/spec/index/filter_spec.rb
@@ -54,7 +54,23 @@ module Ddr::Index
       end
       describe ".has_content" do
         subject { described_class.has_content }
-        its(:clauses) { are_expected.to eq([QueryClause.where(:active_fedora_model, ["Component", "Attachment", "Target"])]) }
+        its(:clauses) {
+          are_expected.to eq([QueryClause.where(:active_fedora_model, ["Component", "Attachment", "Target"])])
+        }
+      end
+      describe ".model" do
+        describe "with a single model" do
+          subject { described_class.model("Component") }
+          its(:clauses) {
+            are_expected.to eq([QueryClause.where(:active_fedora_model, "Component")])
+          }
+        end
+        describe "with a list of models" do
+          subject { described_class.model("Component", "Attachment", "Target") }
+          its(:clauses) {
+            are_expected.to eq([QueryClause.where(:active_fedora_model, ["Component", "Attachment", "Target"])])
+          }
+        end
       end
       describe ".where" do
         subject { described_class.where("foo"=>"bar", "spam"=>"eggs", "stuff"=>["dog", "cat", "bird"]) }
@@ -95,11 +111,22 @@ module Ddr::Index
 
     describe "API methods" do
       describe "#where" do
-        it "adds raw query filters for the hash of conditions" do
+        it "adds query clauses for the hash of conditions" do
           subject.where("foo"=>"bar", "spam"=>"eggs", "stuff"=>["dog", "cat", "bird"])
           expect(subject.clauses).to eq([QueryClause.where("foo", "bar"),
                                          QueryClause.where("spam", "eggs"),
                                          QueryClause.where("stuff", ["dog", "cat", "bird"])
+                                        ])
+        end
+      end
+      describe "#where_not" do
+        it "adds negative query clauses for the hash of conditions" do
+          subject.where_not("foo"=>"bar", "spam"=>"eggs", "stuff"=>["dog", "cat", "bird"])
+          expect(subject.clauses).to eq([QueryClause.negative("foo", "bar"),
+                                         QueryClause.negative("spam", "eggs"),
+                                         QueryClause.negative("stuff", "dog"),
+                                         QueryClause.negative("stuff", "cat"),
+                                         QueryClause.negative("stuff", "bird")
                                         ])
         end
       end

--- a/spec/index/query_clause_spec.rb
+++ b/spec/index/query_clause_spec.rb
@@ -43,7 +43,11 @@ module Ddr::Index
           subject { described_class.where("foo", "Jungle Fever") }
           its(:to_s) { is_expected.to eq "foo:\"Jungle Fever\"" }
         end
-        describe "when the value is an array" do
+        describe "when the value is an Array with one entry" do
+          subject { described_class.where("foo", ["Jungle Fever"]) }
+          its(:to_s) { is_expected.to eq "foo:\"Jungle Fever\"" }
+        end
+        describe "when the value is an array with multiple entries" do
           subject { described_class.where("foo", ["Jungle Fever", "bar"]) }
           its(:to_s) { is_expected.to eq "{!lucene q.op=OR df=foo}\"Jungle Fever\" bar" }
         end

--- a/spec/index/query_spec.rb
+++ b/spec/index/query_spec.rb
@@ -1,26 +1,48 @@
 module Ddr::Index
   RSpec.describe Query do
 
-    let(:id) { UniqueKeyField.instance }
-    let(:foo) { Field.new("foo") }
-    let(:spam) { Field.new("spam") }
-    let(:filter) { Filter.where(spam=>"eggs") }
-    let(:sort_order) { SortOrder.new(field: foo, order: "asc") }
-    let(:fields) { [id, foo, spam] }
+    describe "initialized with attributes" do
+      let(:id) { UniqueKeyField.instance }
+      let(:foo) { Field.new("foo") }
+      let(:spam) { Field.new("spam") }
+      let(:filter) { Filter.where(spam=>"eggs") }
+      let(:sort_order) { SortOrder.new(field: foo, order: "asc") }
+      let(:fields) { [id, foo, spam] }
 
-    subject {
-      described_class.new(q: "foo:bar",
-                          filters: [filter],
-                          fields: fields,
-                          sort: sort_order,
-                          rows: 50)
-    }
+      subject {
+        described_class.new(q: "foo:bar",
+                            filters: [filter],
+                            fields: fields,
+                            sort: sort_order,
+                            rows: 50)
+      }
 
-    its(:to_s) {
-      is_expected.to eq "q=foo%3Abar&fq=spam%3Aeggs&fl=id%2Cfoo%2Cspam&sort=foo+asc&rows=50"
-    }
-    its(:params) {
-      is_expected.to eq({q: "foo:bar", fl: "id,foo,spam", fq: ["spam:eggs"], sort: "foo asc", rows: 50})
-    }
+      its(:to_s) {
+        is_expected.to eq "q=foo%3Abar&fq=spam%3Aeggs&fl=id%2Cfoo%2Cspam&sort=foo+asc&rows=50"
+      }
+      its(:params) {
+        is_expected.to eq({q: "foo:bar", fl: "id,foo,spam", fq: ["spam:eggs"], sort: "foo asc", rows: 50})
+      }
+    end
+
+    describe "initialized with a block" do
+      subject {
+        described_class.new do
+          q "foo:bar"
+          where "spam"=>"eggs"
+          fields :id, "foo", "spam"
+          asc "foo"
+          limit 50
+        end
+      }
+
+      its(:to_s) {
+        is_expected.to eq "q=foo%3Abar&fq=spam%3Aeggs&fl=id%2Cfoo%2Cspam&sort=foo+asc&rows=50"
+      }
+      its(:params) {
+        is_expected.to eq({q: "foo:bar", fl: "id,foo,spam", fq: ["spam:eggs"], sort: "foo asc", rows: 50})
+      }
+    end
+
   end
 end


### PR DESCRIPTION
The block is passed to a QueryBuilder, hence simplifying the whole bit.
New DSL method: `model`
Some kinks worked out of CSVQueryResult.
Query fields are coerced to Field instances.