### PR TITLE
Fixes SolrDocument#has_datastream? ; closes #511

### DIFF
--- a/lib/ddr/models/solr_document.rb
+++ b/lib/ddr/models/solr_document.rb
@@ -90,7 +90,7 @@ module Ddr::Models
     end
 
     def has_datastream?(dsID)
-      datastreams[dsID].present?
+      datastreams.key?(dsID) && datastreams[dsID]["size"].present?
     end
 
     def has_admin_policy?

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -195,4 +195,21 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
       end
     end
   end
+
+  describe "#has_datastream?" do
+    before do
+      allow(subject).to receive(:attached_files) { {"thumbnail"=>{"size"=>nil}, "content"=>{"size"=>987654} }}
+    end
+    context "when there is no content for the datastream" do
+      it "should return false" do
+        expect(subject.has_datastream?("thumbnail")).to be false
+      end
+    end
+    context "when there is content for the datastream" do
+      it "should return true" do
+        expect(subject.has_datastream?("content")).to be true
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
SolrDocument#has_datastream? returns true if the datastream has content and
false if it does not.