### PR TITLE
Runs `identify` on image[0] to determine depth in PTIF generator.

### DIFF
--- a/lib/ddr/derivatives/ptif_generator.rb
+++ b/lib/ddr/derivatives/ptif_generator.rb
@@ -19,7 +19,7 @@ module Ddr
           run_generator(source)
         else
           raise Ddr::Models::DerivativeGenerationFailure,
-                  "Unexpected depth -- #{source_depth} -- for source file #{Ddr::Utils.file_path(source)}"
+                  "Unexpected depth #{source_depth} for source file #{Ddr::Utils.file_path(source)}"
         end
       end
 
@@ -44,7 +44,7 @@ module Ddr
       end
 
       def source_depth
-        `identify -format '%[depth]' #{Ddr::Utils.file_path(source)}`
+        `identify -quiet -format '%[depth]' #{Ddr::Utils.file_path(source)}[0]`
       end
 
     end

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.4.3"
+    VERSION = "2.4.4"
   end
 end


### PR DESCRIPTION
Version 2.4.4
Fixes #528