### PR TITLE
Removes block params from Ddr::Notifications#notify_event.

### DIFF
--- a/lib/ddr/notifications.rb
+++ b/lib/ddr/notifications.rb
@@ -8,9 +8,9 @@ module Ddr
     DELETION = "deletion.events.ddr"
     MIGRATION = "migration.events.ddr"
 
-    def self.notify_event(type, args={}, &block)
+    def self.notify_event(type, args={})
       name = "#{type}.events.ddr"
-      ActiveSupport::Notifications.instrument(name, args, &block)
+      ActiveSupport::Notifications.instrument(name, args)
     end
 
   end

--- a/spec/dummy/config/fedora.yml
+++ b/spec/dummy/config/fedora.yml
@@ -1,0 +1,15 @@
+development:
+  user: fedoraAdmin
+  password: fedoraAdmin
+  url: http://127.0.0.1:8983/fedora/rest
+  base_path: /dev
+test: 
+  user: fedoraAdmin
+  password: fedoraAdmin
+  url: http://127.0.0.1:8983/fedora/rest
+  base_path: /test
+production:
+  user: fedoraAdmin
+  password: fedoraAdmin
+  url: http://127.0.0.1:8080/fedora/rest
+  base_path: /prod

--- a/spec/dummy/config/solr.yml
+++ b/spec/dummy/config/solr.yml
@@ -1,0 +1,6 @@
+development:
+  url: http://localhost:8983/solr/development
+test: 
+  url: <%= "http://localhost:#{ENV['TEST_JETTY_PORT'] || 8983}/solr/test" %>
+production:
+  url: http://your.production.server:8080/bl_solr/core0 


### PR DESCRIPTION
Rolls back change in 0fe075c84b7cd6211424123fdf60cf5e61fa636c.
There was no test and it didn't work.
Also adds Fedora and Solr configs to dummy app for AF >= 9.8.0
compatibility (not required for test suite, but for interactive
console).

Closes #536 