### PR TITLE
Publish/unpublish descendants when publishing/unpublishing objects; c…

### DIFF
--- a/lib/ddr/managers/workflow_manager.rb
+++ b/lib/ddr/managers/workflow_manager.rb
@@ -9,22 +9,34 @@ module Ddr
         object.workflow_state == PUBLISHED
       end
 
+      def publish!(include_descendants: true)
+        unless published?
+          publish
+          object.save
+        end
+        if include_descendants && object.respond_to?(:children)
+          object.children.each { |child| child.publish!(include_descendants: include_descendants) }
+        end
+      end
+
+      def unpublish!
+        if published?
+          unpublish
+          object.save
+        end
+        if object.respond_to?(:children)
+          object.children.each { |child| child.unpublish! }
+        end
+      end
+
+      private
+
       def publish
         object.workflow_state = PUBLISHED
       end
 
-      def publish!
-        publish
-        object.save
-      end
-
       def unpublish
         object.workflow_state = UNPUBLISHED
-      end
-
-      def unpublish!
-        unpublish
-        object.save
       end
 
     end


### PR DESCRIPTION
…loses #42

publish! retains non-default option to publish only the object and not its descendants.