### PR TITLE
Hotfix 2.4.7

### DIFF
--- a/lib/ddr/managers/permanent_id_manager.rb
+++ b/lib/ddr/managers/permanent_id_manager.rb
@@ -13,6 +13,7 @@ module Ddr
       PERMANENT_URL_BASE = "http://id.library.duke.edu/"
       ASSIGN_EVENT_SUMMARY = "Permanent ID assignment"
       SOFTWARE = Ezid::Client.version
+      FCREPO3_PID = "fcrepo3.pid"
 
       attr_reader :object
 
@@ -53,8 +54,9 @@ EZID Metadata:
       end
 
       def default_metadata
-        { profile: "dc",
-          export: "no"
+        { :profile => "dc",
+          :export => "no",
+          FCREPO3_PID => object.pid
         }
       end
 

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.4.6"
+    VERSION = "2.4.7"
   end
 end


### PR DESCRIPTION
Updates default EZID metadata adding the element "fcrepo3.pid"
to assist in tracking.