### PR TITLE
Refactor adminMetadata into a metadata object; closes #550.

### DIFF
--- a/lib/ddr/datastreams.rb
+++ b/lib/ddr/datastreams.rb
@@ -13,10 +13,14 @@ module Ddr
 
     def self.const_missing(name)
       case name
-      when :CONTENT, :DESC_METADATA, :EXTRACTED_TEXT, :FITS, :STRUCT_METADATA, :THUMBNAIL
+      when :CONTENT, :EXTRACTED_TEXT, :FITS, :STRUCT_METADATA, :THUMBNAIL
         Deprecation.warn(self, "Ddr::Datastreams::#{name} is deprecated." \
                                " Use Ddr::Models::File::#{name} instead.")
         Ddr::Models::File.const_get(name)
+      when :DESC_METADATA
+        Deprecation.warn(self, "Ddr::Datastreams::DESC_METADATA is deprecated." \
+                               " Use Ddr::Models::Metadata::DESC_METADATA instead.")
+        Ddr::Models::Metadata::DESC_METADATA
       when :FitsDatastream
         Deprecation.warn(self, "Ddr::Datastreams::FitsDatastream is deprecated." \
                                " Use Ddr::Models::FitsXmlFile instead.")

--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -74,6 +74,7 @@ module Ddr
     end
 
     autoload_under "metadata" do
+      autoload :AdministrativeMetadata
       autoload :DescriptiveMetadata
       autoload :Metadata
       autoload :MetadataMapping

--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -35,6 +35,15 @@ module Ddr::Models
       model_and_id
     end
 
+    def adminMetadata
+      Deprecation.warn(Base, "`adminMetadata` is deprecated; use `admin_metadata` instead.")
+      admin_metadata
+    end
+
+    def admin_metadata
+      @admin_metadata ||= AdministrativeMetadata.new(self)
+    end
+
     def descMetadata
       Deprecation.warn(Base, "`descMetadata` is deprecated; use `desc_metadata` instead.")
       desc_metadata
@@ -42,10 +51,6 @@ module Ddr::Models
 
     def desc_metadata
       @desc_metadata ||= DescriptiveMetadata.new(self)
-    end
-
-    def has_desc_metadata?
-      desc_metadata.has_content?
     end
 
     def desc_metadata_terms(*args)

--- a/lib/ddr/models/file.rb
+++ b/lib/ddr/models/file.rb
@@ -5,7 +5,6 @@ module Ddr::Models
     extend Deprecation
 
     CONTENT         = "content".freeze
-    DESC_METADATA   = "descMetadata".freeze
     EXTRACTED_TEXT  = "extractedText".freeze
     FITS            = "fits".freeze
     STRUCT_METADATA = "structMetadata".freeze
@@ -13,6 +12,15 @@ module Ddr::Models
 
     DEFAULT_FILE_EXTENSION = "bin"
     STRFTIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%LZ"
+
+    def self.const_missing(name)
+      case name
+        when :DESC_METADATA
+          Deprecation.warn(self, "Ddr::File::DESC_METADATA is deprecated." \
+                               " Use Ddr::Models::Metadata::DESC_METADATA instead.")
+          Ddr::Models::Metadata::DESC_METADATA
+      end
+    end
 
     def dsid
       Deprecation.warn(File, "`dsid` is no longer a file method. Use `::File.basename(id)`.")

--- a/lib/ddr/models/metadata/administrative_metadata.rb
+++ b/lib/ddr/models/metadata/administrative_metadata.rb
@@ -1,0 +1,53 @@
+require "forwardable"
+
+module Ddr::Models
+  class AdministrativeMetadata
+    extend Forwardable
+    include Metadata
+
+
+    class << self
+      def field_names
+        [ :access_roles,
+          :admin_set,
+          :aspace_id,
+          :depositor,
+          :display_format,
+          :doi,
+          :ead_id,
+          :fcrepo3_pid,
+          :license,
+          :local_id,
+          :permanent_id,
+          :permanent_url,
+          :research_help_contact,
+          :workflow_state
+        ]
+      end
+
+      alias_method :unqualified_names, :field_names
+      alias_method :field_readers, :field_names
+
+      def field_writers
+        field_names.map { |name| "#{name}=".to_sym }
+      end
+
+      def property_terms
+        field_names.each_with_object({}) do |term, memo|
+          memo[term] = term
+        end
+      end
+
+    end
+
+    attr_reader :object
+
+    def_delegators :object, *field_readers
+    def_delegators :object, *field_writers
+
+    def initialize(object)
+      @object = object
+    end
+
+  end
+end

--- a/lib/ddr/models/metadata/descriptive_metadata.rb
+++ b/lib/ddr/models/metadata/descriptive_metadata.rb
@@ -24,6 +24,13 @@ module Ddr::Models
       def field_writers
         field_names.map { |name| "#{name}=".to_sym }
       end
+
+      def property_terms
+        mapping.terms.each_with_object({}) do |term, memo|
+          memo[term.unqualified_name] = term.qualified_name
+        end
+      end
+
     end
 
     self.mappings = [ MetadataMapping.dcterms, MetadataMapping.duketerms ].freeze

--- a/spec/models/administrative_metadata_spec.rb
+++ b/spec/models/administrative_metadata_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+module Ddr::Models
+  RSpec.describe AdministrativeMetadata do
+
+    let(:obj) { FactoryGirl.build(:item) }
+
+    describe ".property_term" do
+      it "should return the correct property term" do
+        expect(described_class.property_term(:local_id)).to eq(:local_id)
+      end
+    end
+
+    describe "using the set_values and add_value methods" do
+      let(:ds) { described_class.new(obj) }
+      before { ds.local_id = 'foo001' }
+      describe "#set_values" do
+        it "should set the value of the term to the one supplied" do
+          ds.set_value :local_id, 'bar002'
+          expect(ds.local_id).to eq('bar002')
+        end
+      end
+      describe "#add_value" do
+        it "should set the term value to the supplied value" do
+          ds.add_value :local_id, 'bar002'
+          expect(ds.local_id).to eq('bar002')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/descriptive_metadata_spec.rb
+++ b/spec/models/descriptive_metadata_spec.rb
@@ -15,6 +15,11 @@ module Ddr::Models
         expect(subject).to include(*Ddr::Vocab::Vocabulary.term_names(Ddr::Vocab::DukeTerms))
       end
     end
+    describe ".property_term" do
+      it "should return the correct property term" do
+        expect(described_class.property_term(:subject)).to eq(:dc_subject)
+      end
+    end
     describe "using the set_values and add_value methods" do
       let(:ds) { described_class.new(obj) }
       before { ds.type = ["Photograph"] }


### PR DESCRIPTION
Also moves the DESC_METADATA constant from Ddr::Model::File to Ddr::Model::Metadata.