### PR TITLE
Adds index field for "unique ids"

### DIFF
--- a/lib/ddr/index/fields.rb
+++ b/lib/ddr/index/fields.rb
@@ -76,6 +76,7 @@ module Ddr::Index
     TECHMD_WELL_FORMED          = Field.new :techmd_well_formed, :symbol
     TITLE                       = Field.new :title, :stored_sortable
     TYPE_FACET                  = Field.new :type_facet, :facetable
+    UNIQUE_ID                   = Field.new :unique_id, :searchable, type: :symbol
     WORKFLOW_STATE              = Field.new :workflow_state, :stored_sortable
     YEAR_FACET                  = Field.new :year_facet, solr_name: "year_facet_iim"
 

--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -22,8 +22,30 @@ module Ddr::Models
       end
     end
 
+    def self.find_by_unique_id(unique_id)
+      if result = where(Ddr::Index::Fields::UNIQUE_ID => unique_id).first
+        result
+      else
+        raise ActiveFedora::ObjectNotFoundError,
+              "#{self} not found having unique id #{unique_id.inspect}."
+      end
+    end
+
+    def unique_ids
+      [id, permanent_id, permanent_id_suffix].compact
+    end
+
     def inspect
       "#<#{model_and_id}, uri: \"#{uri}\">"
+    end
+
+    def permanent_id_suffix
+      permanent_id && permanent_id.sub(/\Aark:\/\d+\//, "")
+    end
+
+    # @see ActiveModel::Conversion
+    def to_key
+      (key = permanent_id_suffix) ? [key] : super
     end
 
     def model_and_id

--- a/lib/ddr/models/indexing.rb
+++ b/lib/ddr/models/indexing.rb
@@ -45,6 +45,7 @@ module Ddr
           SUBJECT_FACET         => desc_metadata.values('subject'),
           TITLE                 => title_display,
           TYPE_FACET            => desc_metadata.type,
+          UNIQUE_ID             => unique_ids,
           WORKFLOW_STATE        => workflow_state,
           YEAR_FACET            => year_facet,
         }

--- a/spec/models/indexing_spec.rb
+++ b/spec/models/indexing_spec.rb
@@ -12,28 +12,41 @@ module Ddr::Models
       let(:role4) { FactoryGirl.build(:role, :editor, :person, :policy) }
 
       before do
+        obj.aspace_id = "aspace_dccea43034e1b8261e14cf999e86449d"
+        obj.display_format = "Image"
+        obj.doi << "http://doi.org/10.1000/182"
+        obj.fcrepo3_pid = "duke:1"
         obj.license = "cc-by-nc-nd-40"
         obj.local_id = "foo"
-        obj.doi << "http://doi.org/10.1000/182"
         obj.permanent_id = "ark:/99999/fk4zzz"
         obj.permanent_url = "http://id.library.duke.edu/ark:/99999/fk4zzz"
-        obj.display_format = "Image"
         obj.roles.grant role1, role2, role3, role4
-        obj.aspace_id = "aspace_dccea43034e1b8261e14cf999e86449d"
-        obj.fcrepo3_pid = "duke:1"
+        obj.save
+        obj.reload
       end
 
-      its([Indexing::LICENSE]) { is_expected.to eq("cc-by-nc-nd-40") }
-      its([Indexing::LOCAL_ID]) { is_expected.to eq("foo") }
-      its([Indexing::DOI]) { is_expected.to eq(["http://doi.org/10.1000/182"]) }
-      its([Indexing::PERMANENT_ID]) { is_expected.to eq("ark:/99999/fk4zzz") }
-      its([Indexing::PERMANENT_URL]) { is_expected.to eq("http://id.library.duke.edu/ark:/99999/fk4zzz") }
-      its([Indexing::DISPLAY_FORMAT]) { is_expected.to eq("Image") }
       its([Indexing::ACCESS_ROLE]) { is_expected.to eq(obj.roles.to_json) }
       its([Indexing::ASPACE_ID]) { is_expected.to eq("aspace_dccea43034e1b8261e14cf999e86449d") }
-      its([Indexing::POLICY_ROLE]) { is_expected.to contain_exactly(role2.agent, role3.agent, role4.agent) }
-      its([Indexing::RESOURCE_ROLE]) { is_expected.to contain_exactly(role1.agent) }
+      its([Indexing::DISPLAY_FORMAT]) { is_expected.to eq("Image") }
+      its([Indexing::DOI]) { is_expected.to eq(["http://doi.org/10.1000/182"]) }
       its([Indexing::FCREPO3_PID]) { is_expected.to eq("duke:1") }
+      its([Indexing::LICENSE]) { is_expected.to eq("cc-by-nc-nd-40") }
+      its([Indexing::LOCAL_ID]) { is_expected.to eq("foo") }
+      its([Indexing::PERMANENT_ID]) { is_expected.to eq("ark:/99999/fk4zzz") }
+      its([Indexing::PERMANENT_URL]) {
+        is_expected.to eq("http://id.library.duke.edu/ark:/99999/fk4zzz")
+      }
+      its([Indexing::POLICY_ROLE]) {
+        is_expected.to contain_exactly(role2.agent, role3.agent, role4.agent)
+      }
+      its([Indexing::RESOURCE_ROLE]) { is_expected.to contain_exactly(role1.agent) }
+
+      describe "when it doesn't have a permanent id" do
+        before {
+          obj.permanent_id = nil
+        }
+        its([Indexing::UNIQUE_ID]) { is_expected.to eq([obj.id]) }
+      end
     end
 
     describe "content-bearing object indexing" do

--- a/spec/support/shared_examples_for_ddr_models.rb
+++ b/spec/support/shared_examples_for_ddr_models.rb
@@ -6,6 +6,38 @@ RSpec.shared_examples "a DDR model" do
   it_behaves_like "an object that has identifiers"
   it_behaves_like "a fixity checkable object"
 
+  describe "#to_param" do
+    before {
+      subject.save(validate: false) if subject.new_record?
+    }
+    describe "when it has a permanent id" do
+      before {
+        subject.permanent_id = "ark:/99999/fk4rx95k8w"
+      }
+      its(:to_param) { is_expected.to eq("fk4rx95k8w") }
+    end
+    describe "when it does not have a permanent id" do
+      its(:to_param) { is_expected.to_not be_nil }
+      its(:to_param) { is_expected.to eq(subject.id) }
+    end
+  end
+
+  describe ".find_by_unique_id" do
+    before {
+      subject.permanent_id = "ark:/99999/fk4rx95k8w"
+      subject.save(validate: false)
+    }
+    it "finds by Fedora id" do
+      expect(described_class.find_by_unique_id(subject.id)).to eq(subject)
+    end
+    it "finds by permanent id" do
+      expect(described_class.find_by_unique_id("ark:/99999/fk4rx95k8w")).to eq(subject)
+    end
+    it "finds by permanent id suffix" do
+      expect(described_class.find_by_unique_id("fk4rx95k8w")).to eq(subject)
+    end
+  end
+
   describe "events" do
     describe "on deletion with #destroy" do
       before { subject.save(validate: false) }


### PR DESCRIPTION
`Ddr::Index::Fields::UNIQUE_ID` indexes as searchable (not stored)
and array of unique ids for the object. This includes the Fedora ID,
the permanent ID (if present), and the permanent ID "suffix"
(if permanent ID present) -- i.e., the part of the ARK after the
institutional part (NAAN), a.k.a. the "name".  See
https://wiki.ucop.edu/display/Curation/ARK.

The purpose is to enable one search for unique identifiers.  In
ActiveFedora (subclasses of `Ddr::Models::Base`), use
`.find_by_unique_id(unique_id)`.

Closes #568.