### PR TITLE
Revise values of relationship constants; closes #576.

### DIFF
--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise", "~> 3.4"
   s.add_dependency "omniauth-shibboleth", "~> 1.2.0"
   s.add_dependency "grouper-rest-client"
-  s.add_dependency "ezid-client", "~> 1.1", ">= 1.1.1"
+  s.add_dependency "ezid-client", "~> 1.4.1"
   s.add_dependency "resque", "~> 1.25"
   s.add_dependency "rdf-vocab", "~> 0.8"
   s.add_dependency "net-ldap", "~> 0.11"

--- a/lib/ddr/index/fields.rb
+++ b/lib/ddr/index/fields.rb
@@ -28,12 +28,11 @@ module Ddr::Index
     FCREPO3_PID                 = Field.new :fcrepo3_pid, :stored_sortable
     HAS_MODEL                   = Field.new :has_model, :symbol
     IDENTIFIER_ALL              = Field.new :identifier_all, :symbol
-    IS_ATTACHED_TO              = Field.new :is_attached_to, :symbol
-    IS_EXTERNAL_TARGET_FOR      = Field.new :is_external_target_for, :symbol
+    IS_ATTACHED_TO              = Field.new :is_attached_to, solr_name: "isAttachedTo_ssim"
+    IS_EXTERNAL_TARGET_FOR      = Field.new :is_external_target_for, solr_name: "isExternalTargetFor_ssim"
     IS_GOVERNED_BY              = Field.new :is_governed_by, solr_name: "isGovernedBy_ssim"
-    IS_MEMBER_OF                = Field.new :is_member_of, :symbol
-    IS_MEMBER_OF_COLLECTION     = Field.new :is_member_of_collection, :symbol
-    IS_PART_OF                  = Field.new :is_part_of, :symbol
+    IS_MEMBER_OF_COLLECTION     = Field.new :is_member_of_collection, solr_name: "isMemberOfCollection_ssim"
+    IS_PART_OF                  = Field.new :is_part_of, solr_name: "isPartOf_ssim"
     LAST_FIXITY_CHECK_ON        = Field.new :last_fixity_check_on, :stored_sortable, type: :date
     LAST_FIXITY_CHECK_OUTCOME   = Field.new :last_fixity_check_outcome, :symbol
     LAST_VIRUS_CHECK_ON         = Field.new :last_virus_check_on, :stored_sortable, type: :date

--- a/spec/models/has_admin_metadata_spec.rb
+++ b/spec/models/has_admin_metadata_spec.rb
@@ -78,8 +78,9 @@ module Ddr::Models
       describe "events" do
         before { allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { true } }
         context "when the operation succeeds" do
-          let!(:mock_identifier) { Ezid::MockIdentifier.new(id: "ark:/99999/fk4zzz",
-                                                            metadata: "_target: http://example.com") }
+          let!(:mock_identifier) {
+            Ezid::MockIdentifier.new("ark:/99999/fk4zzz", metadata: "_target: http://example.com")
+          }
           before do
             allow(Ezid::Identifier).to receive(:create) { mock_identifier }
             allow(Ezid::Identifier).to receive(:find) { mock_identifier }

--- a/spec/support/ezid_mock_identifier.rb
+++ b/spec/support/ezid_mock_identifier.rb
@@ -6,8 +6,8 @@ module Ezid
 
     self.defaults = {}
 
-    def reload; self; end
-    def reset; self; end
+    def load_metadata; self; end
+    def reset_metadata; self; end
 
     private
 


### PR DESCRIPTION
Due to change in how ActiveFedora indexes these attributes.
Also removes unused IS_MEMBER_OF constant.