### PR TITLE
Adds a notification after save to Ddr::Models::Base

### DIFF
--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -13,6 +13,12 @@ module Ddr::Models
     extend AutoVersion
     extend Relation
 
+    SAVE_NOTIFICATION = "save.base.models.ddr"
+
+    after_save do
+      ActiveSupport::Notifications.instrument(SAVE_NOTIFICATION, id: id)
+    end
+
     after_destroy do
       notify_event :deletion
     end

--- a/spec/support/shared_examples_for_ddr_models.rb
+++ b/spec/support/shared_examples_for_ddr_models.rb
@@ -213,4 +213,20 @@ RSpec.shared_examples "a DDR model" do
       end
     end
   end
+
+  describe "after save notification" do
+    let(:events) { [] }
+    before {
+      @subscriber = ActiveSupport::Notifications.subscribe(Ddr::Models::Base::SAVE_NOTIFICATION) do |name, start, finish, id, payload|
+        events << payload[:id]
+      end
+    }
+    after {
+      ActiveSupport::Notifications.unsubscribe(@subscriber)
+    }
+    specify {
+      subject.save(validate: false)
+      expect(events).to eq([subject.id])
+    }
+  end
 end


### PR DESCRIPTION
This provides a way, for example, for dul-hydra to subscribe to
object save events.