### PR TITLE
Extends Ddr::Models::YearFacet date handling to include several EDTF formats

### DIFF
--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ddr-antivirus", "~> 2.1.1"
   s.add_dependency "virtus", "~> 1.0.5"
   s.add_dependency "hashie", "~> 3.4.3"
+  s.add_dependency "edtf", "~> 2.3"
 
   s.add_development_dependency "bundler", "~> 1.11", ">= 1.11.2"
   s.add_development_dependency "rake"

--- a/lib/ddr/models/year_facet.rb
+++ b/lib/ddr/models/year_facet.rb
@@ -1,153 +1,95 @@
 require "date"
+require "edtf"
 
 module Ddr::Models
   class YearFacet
 
     EARLIEST_YEAR = 1000
+    LATEST_YEAR = Date.today.year + 100
+    VALID_YEARS = (EARLIEST_YEAR..LATEST_YEAR)
+    VALUE_SEP = /;/
 
     # Between 1965 and 1968
     BETWEEN = Regexp.new '\A([Bb]etween\s+)(\d{4})(\s+and\s+)(\d{4})\??\z'
 
-    # YYYx (192x)
-    # YYYX (192X)
-    # YYY? (192?)
-    # YYY- (192-)
-    # YYY-? (192-?)
-    IN_DECADE = Regexp.new '\A(\d{3})([xX\-]\??|\?)\z'
-
-    # YYxx (19xx)
-    IN_CENTURY = Regexp.new '\A(\d{2})xx\z'
-
-    # YYY0s (1920s)
-    # YYY0s? (1920s?)
-    DECADE = Regexp.new '\A(\d{3}0)s\??\z'
-
-    # YYYY-MM (2010-01)
-    # YYYY/MM (2010/01)
-    YEAR_MONTH = Regexp.new '\A(\d{4})[/-](0[1-9]|1[0-2])\z'
-
-    # YYYY-YYYY (1935-2010)
-    # YYYY/YYYY (1935/2010)
-    YEAR_RANGE = Regexp.new '\A(\d{4})[/-](\d{4})\z'
-
-    # YYYY (1979)
-    YEAR = Regexp.new '\A\d{4}\z'
-
-    SQUARE_BRACKETS = Regexp.new '[\[\]]'
-
-    # c. 1920
-    # ca. 1920
-    # c1920
+    # circa 1920, ca. 1920, c1920 => 1920
     CIRCA = Regexp.new '\b(circa\s+|ca?\.\s*|c(?=\d{4}[^\d]*))'
 
-    class << self
-      def call(obj)
-        new(obj).values
-      end
+    # 1935-1940 => 1935/1940
+    YEAR_RANGE = Regexp.new '(?<=\d{4})-(?=\d{4})'
+
+    # 1920s, 1920s?, 192u, 192-, 192-?, 192? => 192x
+    DECADE = Regexp.new '(?<=\A\d{3})(-\??|0s\??|u|\?)\z'
+
+    # 2010/01 => 2010-01
+    MONTH = Regexp.new '(?<=\A\d{4})\/(?=\d{2}\z)'
+
+    # 193u/, 193x/ => 1930/
+    START_DECADE = Regexp.new '(?<=\d{3})[uxX](?=\/)'
+
+    # /194x, /194u => /1949
+    END_DECADE = Regexp.new '(?<=\/\d{3})[uxX]'
+
+    # 19uu => 19xx
+    CENTURY = Regexp.new '(?<=\A\d{2})uu(?=\z)'
+
+    def self.call(object)
+      new(object).call
     end
 
-    attr_reader :obj, :values
+    attr_reader :object
 
-    def initialize(obj)
-      @obj = obj
-      @values = []
-      facet_values
+    def initialize(object)
+      @object = object
     end
 
-    def facet_values
-      obj.desc_metadata.date.each do |date|
-        date.split(/;/).each do |value|
-          clean! value
-          years = extract_years(value)
-          validate! years
-          values.push *years
+    def call
+      source_dates.each_with_object([]) do |date, facet_values|
+        date.split(VALUE_SEP).each do |value|
+          value.strip!
+          edtf_date = convert_to_edtf(value)
+          years = Array(edtf_years(edtf_date))
+          years.select! { |year| VALID_YEARS.include?(year) }
+          facet_values.push(*years)
         end
       end
     end
 
-    def extract_years(value)
-      years = match_years(value) || parse_year(value)
-      Array(years)
+    private
+
+    def source_dates
+      object.desc_metadata.date
     end
 
-    def clean!(value)
-      value.strip!
-      value.gsub! SQUARE_BRACKETS, ""
-      value.gsub! CIRCA, ""
-    end
-
-    def validate!(years)
-      years = years & valid_years.to_a
-    end
-
-    def parse_year(value)
-      Date.parse(value).year
-    rescue ArgumentError
-      nil
-    end
-
-    def valid_years
-      (EARLIEST_YEAR..latest_year)
-    end
-
-    def latest_year
-      Date.today.year + 100
-    end
-
-    def match_years(value)
-      result = match_year_range(value) ||
-               match_year_month(value) ||
-               match_year(value) ||
-               match_in_decade(value) ||
-               match_in_century(value) ||
-               match_decade(value) ||
-               match_between(value)
-      first_year, last_year = Array(result).map(&:to_i)
-      last_year ? (first_year..last_year) : first_year
-    end
-
-    def match_year_range(value)
-      if m = YEAR_RANGE.match(value)
-        m[1, 2]
-      end
-    end
-
-    def match_year_month(value)
-      if m = YEAR_MONTH.match(value)
-        m[1]
-      end
-    end
-
-    def match_year(value)
-      if m = YEAR.match(value)
-        value
-      end
-    end
-
-    def match_in_decade(value)
-      if m = IN_DECADE.match(value)
-        [ "#{m[1]}0", "#{m[1]}9" ]
-      end
-    end
-
-    def match_in_century(value)
-      if m = IN_CENTURY.match(value)
-        [ "#{m[1]}00", "#{m[1]}99" ]
-      end
-    end
-
-    def match_decade(value)
-      if m = DECADE.match(value)
-        [ m[1], m[1].sub(/0\z/, "9") ]
-      end
-    end
-
-    def match_between(value)
+    def convert_to_edtf(value)
       if m = BETWEEN.match(value)
         value.sub! m[1], ""  # [Bb]etween
-        value.sub! m[3], "-" # and
-        match_year_range(value)
+        value.sub! m[3], "/" # and
       end
+      substitutions.reduce(value) { |memo, (regexp, repl)| memo.gsub(regexp, repl) }
+    end
+
+    def substitutions
+      [
+        [ CIRCA,         "" ],
+        [ YEAR_RANGE,   "/" ],
+        [ DECADE,       "x" ],
+        [ MONTH,        "-" ],
+        [ START_DECADE, "0" ],
+        [ END_DECADE,   "9" ],
+        [ CENTURY,     "xx" ],
+      ]
+    end
+
+    def edtf_years(value)
+      case parsed = EDTF.parse!(value)
+      when Date, EDTF::Season
+        parsed.year
+      when EDTF::Set, EDTF::Interval, EDTF::Epoch
+        parsed.map(&:year).uniq
+      end
+    rescue ArgumentError # EDTF cannot parse
+      nil
     end
 
   end

--- a/spec/models/year_facet_spec.rb
+++ b/spec/models/year_facet_spec.rb
@@ -1,64 +1,91 @@
 module Ddr::Models
   RSpec.describe YearFacet do
 
-    subject { described_class.new(obj) }
+    subject { described_class.call(obj) }
     let(:obj) { Item.new }
     before { obj.dc_date = [ date ] }
 
     describe "splitting on semicolons" do
       let(:date) { "1935; 1936; 1937; 1938" }
-      its(:values) { is_expected.to eq([1935, 1936, 1937, 1938]) }
+      it { is_expected.to eq([1935, 1936, 1937, 1938]) }
     end
 
     describe "year range" do
-      %w( 1935-1940 1935/1940 ).each do |value|
+      %w( 1935-1940 1935/1940 1935?/1940? 1935~/1940~ ).each do |value|
         describe value do
           let(:date) { value }
-          its(:values) { is_expected.to eq((1935..1940).to_a) }
+          it { is_expected.to eq((1935..1940).to_a) }
         end
       end
-    end
-
-    describe "in decade" do
-      %w( 192x 192X 192? 192- 192-? ).each do |value|
-        describe value do
-          let(:date) { value }
-          its(:values) { is_expected.to eq((1920..1929).to_a) }
-        end
-      end
-    end
-
-    describe "in century -- YYxx (19xx)" do
-      let(:date) { "19xx" }
-      its(:values) { is_expected.to eq((1900..1999).to_a) }
     end
 
     describe "decade" do
-      %w( 1920s 1920s? ).each do |value|
+      %w( 192u 192x 192X 192? 192- 192-? 1920s 1920s? ).each do |value|
         describe value do
           let(:date) { value }
-          its(:values) { is_expected.to eq((1920..1929).to_a) }
+          it { is_expected.to eq((1920..1929).to_a) }
         end
       end
     end
 
-    describe "year + month" do
-      %w( 2010-01 2010/01 ).each do |value|
+    describe "century" do
+      %w( 19xx 19uu ).each do |value|
         describe value do
           let(:date) { value }
-          its(:values) { is_expected.to eq([2010]) }
+          it { is_expected.to eq((1900..1999).to_a) }
+        end
+      end
+    end
+
+    describe "uncertain interval" do
+      let(:date) { "199u/200u" }
+      it { is_expected.to eq((1990..2009).to_a) }
+    end
+
+    describe "set" do
+      let(:date) { "[1999,2000,2003]" }
+      it { is_expected.to eq([1999, 2000, 2003]) }
+    end
+
+    describe "year" do
+      %w( 2010 2010? 2010~ ).each do |value|
+        describe value do
+          let(:date) { value }
+          it { is_expected.to eq([2010]) }
+        end
+      end
+    end
+
+    describe "month" do
+      %w( 2010-01 2010/01 2010-12? 2010-11/2010-12 ).each do |value|
+        describe value do
+          let(:date) { value }
+          it { is_expected.to eq([2010]) }
+        end
+      end
+    end
+
+    describe "day" do
+      %w( 2010-12-10 2010-12-10? 2010-12-10/2010-12-20 ).each do |value|
+        describe value do
+          let(:date) { value }
+          it { is_expected.to eq([2010]) }
+        end
+      end
+    end
+
+    describe "season" do
+      %w( 2010-21 2010-22 2010-23 2010-24 ).each do |value|
+        describe value do
+          let(:date) { value }
+          it { is_expected.to eq([2010]) }
         end
       end
     end
 
     describe "between" do
       let(:date) { "Between 1965 and 1968" }
-      its(:values) { is_expected.to eq((1965..1968).to_a) }
-    end
-
-    describe "year" do
-      let(:date) { "1965" }
-      its(:values) { is_expected.to eq([1965]) }
+      it { is_expected.to eq((1965..1968).to_a) }
     end
 
   end


### PR DESCRIPTION
The class has been reoriented to parse dates with edtf-ruby.
Closes #615