### PR TITLE
Ddr::Index::CSVQueryResult refactored.

### DIFF
--- a/lib/ddr/index/connection.rb
+++ b/lib/ddr/index/connection.rb
@@ -1,3 +1,5 @@
+require "rsolr"
+
 module Ddr::Index
   class Connection < SimpleDelegator
 

--- a/lib/ddr/index/csv_options.rb
+++ b/lib/ddr/index/csv_options.rb
@@ -3,12 +3,10 @@ require "hashie"
 
 module Ddr::Index
   class CSVOptions < Hashie::Dash
-
     property :headers,        default: CSV::DEFAULT_OPTIONS[:headers]
-    property :return_headers, default: true
+    property :return_headers, default: false
     property :write_headers,  default: true
     property :col_sep,        default: CSV::DEFAULT_OPTIONS[:col_sep]
     property :quote_char,     default: CSV::DEFAULT_OPTIONS[:quote_char]
-
   end
 end

--- a/lib/ddr/index/query.rb
+++ b/lib/ddr/index/query.rb
@@ -46,8 +46,8 @@ module Ddr::Index
       QueryResult.new(self)
     end
 
-    def csv(**opts)
-      CSVQueryResult.new(self, **opts)
+    def csv
+      CSVQueryResult.new(self)
     end
 
     def filter_clauses

--- a/lib/ddr/index/solr_csv_options.rb
+++ b/lib/ddr/index/solr_csv_options.rb
@@ -3,12 +3,15 @@ require "hashie"
 module Ddr::Index
   class SolrCSVOptions < Hashie::Trash
 
+    MAX_ROWS   = 10**8
+    CSV_MV_SEPARATOR = ";"
+
     property "csv.header",       from: :header,     default: false
     property "csv.separator",    from: :col_sep,    default: ","
     property "csv.encapsulator", from: :quote_char, default: '"'
-    property "csv.mv.separator", from: :mv_sep,     default: ","
+    property "csv.mv.separator", default: CSV_MV_SEPARATOR
     property :wt,                default: "csv"
-    property :rows
+    property :rows,              default: MAX_ROWS
 
     def params
       to_h.reject { |k, v| v.nil? }

--- a/spec/index/csv_query_result_spec.rb
+++ b/spec/index/csv_query_result_spec.rb
@@ -1,0 +1,42 @@
+module Ddr::Index
+  RSpec.describe CSVQueryResult do
+
+    subject { described_class.new(query) }
+
+    before do
+      Item.create(dc_title: ["Testing 1"],
+                  dc_identifier: ["test1"],
+                  dc_description: ["The process of eliminating errors."])
+      Item.create(dc_title: ["Testing 2"],
+                  dc_identifier: ["test2"])
+      Item.create(dc_title: ["Testing 3"])
+    end
+
+    let(:query) {
+      Ddr::Index::Query.new do
+        fields Ddr::Index::Fields::ID
+        fields Ddr::Index::Fields.descmd
+      end
+    }
+
+    specify {
+      expect(subject["dc_title"]).to contain_exactly("Testing 1", "Testing 2", "Testing 3")
+      expect(subject["dc_identifier"]).to contain_exactly("test1", "test2", nil)
+      expect(subject["dc_description"]).to contain_exactly("The process of eliminating errors.", nil, nil)
+      expect(subject["dc_creator"]).to contain_exactly(nil, nil, nil)
+      expect(subject.to_s).to match(/dc_creator/)
+    }
+
+    describe "#delete_empty_columns!" do
+      specify {
+        subject.delete_empty_columns!
+        expect(subject["dc_title"]).to contain_exactly("Testing 1", "Testing 2", "Testing 3")
+        expect(subject["dc_identifier"]).to contain_exactly("test1", "test2", nil)
+        expect(subject["dc_description"]).to contain_exactly("The process of eliminating errors.", nil, nil)
+        expect(subject["dc_creator"]).to contain_exactly(nil, nil, nil)
+        expect(subject.to_s).not_to match(/dc_creator/)
+      }
+    end
+
+  end
+end


### PR DESCRIPTION
Adds #delete_empty_columns! method to remove empty columns
from underlying CSV table (closes #599).