### PR TITLE
Adds DOI to all_identifiers for indexing.

### DIFF
--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -128,6 +128,16 @@ module Ddr
       Dir.tmpdir
     end
 
+    mattr_accessor :all_identifiers do
+      [ :id,
+        :fcrepo3_pid,
+        :dc_identifier,
+        :local_id,
+        :permanent_id,
+        :doi,
+      ]
+    end
+
     # Yields an object with module configuration accessors
     def self.configure
       yield self

--- a/lib/ddr/models/indexing.rb
+++ b/lib/ddr/models/indexing.rb
@@ -102,7 +102,7 @@ module Ddr
       end
 
       def all_identifiers
-        desc_metadata.identifier + [fcrepo3_pid, local_id, permanent_id, id].compact
+        Ddr::Models.all_identifiers.map { |meth| send(meth) }.flatten.compact
       end
 
       def associated_collection

--- a/spec/models/indexing_spec.rb
+++ b/spec/models/indexing_spec.rb
@@ -26,6 +26,9 @@ module Ddr::Models
       end
 
       its([Indexing::ACCESS_ROLE]) { is_expected.to eq(obj.roles.to_json) }
+      its([Indexing::IDENTIFIER_ALL]) {
+        is_expected.to contain_exactly(obj.id, obj.dc_identifier.first, "ark:/99999/fk4zzz", "http://doi.org/10.1000/182", "duke:1", "foo")
+      }
       its([Indexing::ASPACE_ID]) { is_expected.to eq("aspace_dccea43034e1b8261e14cf999e86449d") }
       its([Indexing::DISPLAY_FORMAT]) { is_expected.to eq("Image") }
       its([Indexing::DOI]) { is_expected.to eq("http://doi.org/10.1000/182") }


### PR DESCRIPTION
Closes #609
Indexed identifier methods available in config Ddr::Models.all_identifiers.