### PR TITLE
Hotfix 3.0.1

### DIFF
--- a/lib/ddr/models/solr_document.rb
+++ b/lib/ddr/models/solr_document.rb
@@ -98,23 +98,18 @@ module Ddr::Models
     end
 
     def has_admin_policy?
-      admin_policy_uri.present?
+      admin_policy_id.present?
     end
 
-    def admin_policy_uri
+    def admin_policy_id
       is_governed_by
     end
-
-    def admin_policy_pid
-      uri = admin_policy_uri
-      uri &&= ActiveFedora::Base.pid_from_uri(uri)
-    end
-    alias_method :admin_policy_id, :admin_policy_pid
+    alias_method :admin_policy_pid, :admin_policy_id
+    alias_method :admin_policy_uri, :admin_policy_id
+    deprecation_deprecate :admin_policy_pid, :admin_policy_uri
 
     def admin_policy
-      if has_admin_policy?
-        self.class.find(admin_policy_uri)
-      end
+      self.class.find(admin_policy_id) if has_admin_policy?
     end
 
     def has_children?
@@ -211,18 +206,18 @@ module Ddr::Models
       Ddr::Models::Contact.call(research_help_contact) if research_help_contact
     end
 
-    def parent_uri
+    def parent_id
       is_part_of || is_member_of_collection
     end
+    alias_method :parent_uri, :parent_id
+    deprecation_deprecate :parent_uri
 
     def has_parent?
-      parent_uri.present?
+      parent_id.present?
     end
 
     def parent
-      if has_parent?
-        self.class.find(parent_uri)
-      end
+      self.class.find(parent_id) if has_parent?
     end
 
     def multires_image_file_paths(type='default')

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "3.0.0"
+    VERSION = "3.0.1"
   end
 end

--- a/spec/models/effective_license_spec.rb
+++ b/spec/models/effective_license_spec.rb
@@ -4,70 +4,77 @@ module Ddr::Models
     subject { described_class.call(obj) }
 
     let(:url) { "https://creativecommons.org/licenses/by-nc-nd/4.0/" }
-
     let(:license) { License.new(url: url) }
-
-    let(:obj) { Component.new(id: "test-1") }
     let(:parent) { Item.new(id: "test-2") }
     let(:admin_policy) { Collection.new(id: "test-3") }
 
-    describe "when the object has a license" do
-      before do
-        allow(License).to receive(:call).with(obj) { license }
-      end
-      it { is_expected.to eq(license) }
-    end
-
-    describe "when the object does not have a license" do
-      before do
-        allow(License).to receive(:call).with(obj) { nil }
-      end
-      describe "and the object has a parent" do
+    shared_examples "an effective license" do
+      describe "when the object has a license" do
         before do
-          allow(obj).to receive(:parent) { parent }
+          allow(License).to receive(:call).with(obj) { license }
         end
-        describe "and the parent has a license" do
-          before do
-            allow(License).to receive(:call).with(parent) { license }
-          end
-          it { is_expected.to eq(license) }
-        end
-        describe "and the parent does not have a license" do
-          before do
-            allow(License).to receive(:call).with(parent) { nil }
-          end
-          it { is_expected.to be_nil }
-        end
+        it { is_expected.to eq(license) }
       end
-      describe "and the object does not have a parent" do
-        describe "and the object has an admin policy" do
-          before { allow(obj).to receive(:admin_policy) { admin_policy } }
-          describe "and the admin policy has a different id from the object" do
-            before do
-              allow(obj).to receive(:admin_policy_id) { "test-3" }
-            end
-            describe "and the admin policy has a license" do
-              before do
-                allow(License).to receive(:call).with(admin_policy) { license }
-              end
-              it { is_expected.to eq(license) }
-            end
-            describe "and the admin policy does not have a license" do
-              before do
-                allow(License).to receive(:call).with(admin_policy) { nil }
-              end
-              it { is_expected.to be_nil }
-            end
+
+      describe "when the object does not have a license" do
+        before do
+          allow(License).to receive(:call).with(obj) { nil }
+        end
+        describe "and the object has a parent" do
+          before do
+            allow(obj).to receive(:parent) { parent }
           end
-          describe "and the admin policy has the same id as the object" do
-            before { allow(obj).to receive(:admin_policy_id) { obj.id } }
+          describe "and the parent has a license" do
+            before do
+              allow(License).to receive(:call).with(parent) { license }
+            end
+            it { is_expected.to eq(license) }
+          end
+          describe "and the parent does not have a license" do
+            before do
+              allow(License).to receive(:call).with(parent) { nil }
+            end
             it { is_expected.to be_nil }
           end
         end
-        describe "and the object does not have an admin policy" do
-          it { is_expected.to be_nil }
+        describe "and the object does not have a parent" do
+          describe "and the object has an admin policy" do
+            before { allow(obj).to receive(:admin_policy) { admin_policy } }
+            describe "and the admin policy has a different id from the object" do
+              before do
+                allow(obj).to receive(:admin_policy_id) { "test-3" }
+              end
+              describe "and the admin policy has a license" do
+                before do
+                  allow(License).to receive(:call).with(admin_policy) { license }
+                end
+                it { is_expected.to eq(license) }
+              end
+              describe "and the admin policy does not have a license" do
+                before do
+                  allow(License).to receive(:call).with(admin_policy) { nil }
+                end
+                it { is_expected.to be_nil }
+              end
+            end
+            describe "and the admin policy has the same id as the object" do
+              before { allow(obj).to receive(:admin_policy_id) { obj.id } }
+              it { is_expected.to be_nil }
+            end
+          end
+          describe "and the object does not have an admin policy" do
+            it { is_expected.to be_nil }
+          end
         end
       end
+    end
+
+    it_behaves_like "an effective license" do
+      let(:obj) { Component.new(id: "test-1") }
+    end
+
+    it_behaves_like "an effective license" do
+      let(:obj) { ::SolrDocument.new(id: "test-1") }
     end
 
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -25,20 +25,20 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
     end
   end
 
-  describe "#admin_policy_uri" do
+  describe "#admin_policy_id" do
     describe "when is_governed_by is not set" do
-      its(:admin_policy_uri) { is_expected.to be_nil }
+      its(:admin_policy_id) { is_expected.to be_nil }
     end
     describe "when is_governed_by is set" do
-      before { subject[Ddr::Index::Fields::IS_GOVERNED_BY] = "info:fedora/test:1" }
-      its(:admin_policy_uri) { should eq("info:fedora/test:1") }
+      before { subject[Ddr::Index::Fields::IS_GOVERNED_BY] = "test-1" }
+      its(:admin_policy_id) { is_expected.to eq("test-1") }
     end
   end
 
   describe "#admin_policy" do
     describe "when there is not an admin policy relationship" do
-      before { allow(subject).to receive(:admin_policy_pid) { nil } }
-      its(:admin_policy) { should be_nil }
+      before { allow(subject).to receive(:admin_policy_id) { nil } }
+      its(:admin_policy) { is_expected.to be_nil }
     end
     describe "where there is an admin policy relationship" do
       let(:admin_policy) { FactoryGirl.create(:collection) }
@@ -51,28 +51,28 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
     end
   end
 
-  describe "#parent_uri" do
+  describe "#parent_id" do
     describe "when is_part_of is present" do
-      before { subject[Ddr::Index::Fields::IS_PART_OF] = "info:fedora/test:1" }
-      its(:parent_uri) { is_expected.to eq("info:fedora/test:1") }
+      before { subject[Ddr::Index::Fields::IS_PART_OF] = "test-1" }
+      its(:parent_id) { is_expected.to eq("test-1") }
     end
     describe "when is_part_of is not present" do
       describe "when is_member_of_collection is present" do
-        before { subject[Ddr::Index::Fields::IS_MEMBER_OF_COLLECTION] = "info:fedora/test:1" }
-        its(:parent_uri) { is_expected.to eq("info:fedora/test:1") }
+        before { subject[Ddr::Index::Fields::IS_MEMBER_OF_COLLECTION] = "test-1" }
+        its(:parent_id) { is_expected.to eq("test-1") }
       end
       describe "when is_member_of_collection is not present" do
-        its(:parent_uri) { is_expected.to be_nil }
+        its(:parent_id) { is_expected.to be_nil }
       end
     end
   end
 
   describe "#parent" do
-    describe "when there is a parent URI" do
-      let(:doc) { described_class.new({"id"=>"test:1"}) }
+    describe "when there is a parent ID" do
+      let(:doc) { described_class.new({"id"=>"test-1"}) }
       before do
-        allow(subject).to receive(:parent_uri) { "info:fedora/test:1" }
-        allow(described_class).to receive(:find).with("info:fedora/test:1") { doc }
+        allow(subject).to receive(:parent_id) { "test-1" }
+        allow(described_class).to receive(:find).with("test-1") { doc }
       end
       its(:parent) { is_expected.to eq(doc) }
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,12 +76,12 @@ RSpec.configure do |config|
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
-  end
+  # if config.files_to_run.one?
+  #   # Use the documentation formatter for detailed output,
+  #   # unless a formatter has already been configured
+  #   # (e.g. via a command-line flag).
+  #   config.default_formatter = 'doc'
+  # end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running


### PR DESCRIPTION
Fixes #628
Adds test coverage for SolrDocument#effective_license.
Deprecates legacy methods of SolrDocument.