### PR TITLE
Add local_id to default struct_map; closes #645.

### DIFF
--- a/lib/ddr/models/has_struct_metadata.rb
+++ b/lib/ddr/models/has_struct_metadata.rb
@@ -39,13 +39,14 @@ module Ddr
       end
 
       def add_to_struct_map(stru, child)
-        div = create_div(stru)
+        div = create_div(stru, child[Ddr::Index::Fields::LOCAL_ID])
         create_fptr(stru, div, child['id'])
       end
 
-      def create_div(stru)
+      def create_div(stru, local_id)
         div_count = stru.structMap_node('default').xpath('xmlns:div').size
         div = Nokogiri::XML::Node.new('div', stru.as_xml_document)
+        div['ID'] = local_id if local_id.present?
         div['ORDER'] = div_count + 1
         stru.structMap_node('default').add_child(div)
         div

--- a/spec/factories/structure_factories.rb
+++ b/spec/factories/structure_factories.rb
@@ -10,6 +10,12 @@ FactoryGirl.define do
       end
     end
 
+    factory :simple_structure_without_local_id do
+      initialize_with do
+        new(simple_structure_document_without_local_id)
+      end
+    end
+
     factory :nested_structure do
       initialize_with do
         new(nested_structure_document)

--- a/spec/models/has_struct_metadata_spec.rb
+++ b/spec/models/has_struct_metadata_spec.rb
@@ -21,15 +21,29 @@ module Ddr
       end
 
       describe "#build_default_structure" do
-        let(:components) { [ Component.new(id: 'test_5', identifier: [ 'abc002' ]),
-                             Component.new(id: 'test_6', identifier: [ 'abc001' ]),
-                             Component.new(id: 'test_7', identifier: [ 'abc003' ])
-                           ] }
-        let(:expected) { FactoryGirl.build(:simple_structure) }
-        before { allow(item).to receive(:find_children) { simple_structure_query_response } }
-        it "should build the appropriate structural metadata" do
-          results = item.build_default_structure
-          expect(results).to be_equivalent_to(expected)
+        context "with local_id's" do
+          let(:components) { [ Component.new(id: 'test_5', local_id: 'abc002'),
+                               Component.new(id: 'test_6', local_id: 'abc001'),
+                               Component.new(id: 'test_7', local_id: 'abc003')
+                             ] }
+          let(:expected) { FactoryGirl.build(:simple_structure) }
+          before { allow(item).to receive(:find_children) { simple_structure_query_response } }
+          it "should build the appropriate structural metadata" do
+            results = item.build_default_structure
+            expect(results).to be_equivalent_to(expected)
+          end
+        end
+        context "without local_id's" do
+          let(:components) { [ Component.new(id: 'test_5'),
+                               Component.new(id: 'test_6'),
+                               Component.new(id: 'test_7')
+          ] }
+          let(:expected) { FactoryGirl.build(:simple_structure_without_local_id) }
+          before { allow(item).to receive(:find_children) { simple_structure_without_local_id_query_response } }
+          it "should build the appropriate structural metadata" do
+            results = item.build_default_structure
+            expect(results).to be_equivalent_to(expected)
+          end
         end
       end
 

--- a/spec/support/structural_metadata_helper.rb
+++ b/spec/support/structural_metadata_helper.rb
@@ -6,6 +6,12 @@ def simple_structure_document
   end
 end
 
+def simple_structure_document_without_local_id
+  Nokogiri::XML(simple_structure_without_local_id) do |config|
+    config.noblanks
+  end
+end
+
 def nested_structure_document
   Nokogiri::XML(nested_structure) do |config|
     config.noblanks
@@ -19,6 +25,24 @@ def multiple_struct_maps_structure_document
 end
 
 def simple_structure
+  <<-eos
+    <mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <structMap TYPE="default">
+        <div ID="abc001" ORDER="1">
+          <fptr CONTENTIDS="test_6" />
+        </div>
+        <div ID="abc002" ORDER="2">
+          <fptr CONTENTIDS="test_5" />
+        </div>
+        <div ID="abc003" ORDER="3">
+          <fptr CONTENTIDS="test_7" />
+        </div>
+      </structMap>
+    </mets>
+  eos
+end
+
+def simple_structure_without_local_id
   <<-eos
     <mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
       <structMap TYPE="default">
@@ -46,10 +70,10 @@ def nested_structure
         <div ORDER="2" LABEL="Back">
           <div ORDER="1" LABEL="Top">
             <fptr CONTENTIDS="test_7" />
-          </div>    
+          </div>
           <div ORDER="2" LABEL="Bottom">
             <fptr CONTENTIDS="test_6" />
-          </div>    
+          </div>
         </div>
       </structMap>
     </mets>
@@ -66,10 +90,10 @@ def multiple_struct_maps_structure
         <div ORDER="2" LABEL="Back">
           <div ORDER="1" LABEL="Top">
             <fptr CONTENTIDS="test_7" />
-          </div>    
+          </div>
           <div ORDER="2" LABEL="Bottom">
             <fptr CONTENTIDS="test_6" />
-          </div>    
+          </div>
         </div>
       </structMap>
       <structMap TYPE="reverse">
@@ -79,7 +103,7 @@ def multiple_struct_maps_structure
           </div>
           <div ORDER="2" LABEL="Top">
             <fptr CONTENTIDS="test_7" />
-          </div>    
+          </div>
         </div>
         <div ORDER="2" LABEL="Front">
           <fptr CONTENTIDS="test_5" />
@@ -93,13 +117,17 @@ def simple_structure_query_response
   [ { "id"=>"test_6", "local_id_ssi"=>"abc001"  }, { "id"=>"test_5", "local_id_ssi"=>"abc002" }, { "id"=>"test_7", "local_id_ssi"=>"abc003" } ]
 end
 
+def simple_structure_without_local_id_query_response
+  [ { "id"=>"test_6", "system_create_dtsi" => "2016-05-23T13:02:07Z" }, { "id"=>"test_5", "system_create_dtsi" => "2016-05-23T13:02:09Z" }, { "id"=>"test_7", "system_create_dtsi" => "2016-05-23T13:02:12Z" } ]
+end
+
 def simple_structure_to_json
   j = <<-eos
     {\"default\":
       {\"type\":\"default\",
-        \"divs\":[{\"order\":\"1\",\"fptrs\":[\"test_6\"],\"divs\":[]},
-                  {\"order\":\"2\",\"fptrs\":[\"test_5\"],\"divs\":[]},
-                  {\"order\":\"3\",\"fptrs\":[\"test_7\"],\"divs\":[]}
+        \"divs\":[{\"id\":\"abc001\",\"order\":\"1\",\"fptrs\":[\"test_6\"],\"divs\":[]},
+                  {\"id\":\"abc002\",\"order\":\"2\",\"fptrs\":[\"test_5\"],\"divs\":[]},
+                  {\"id\":\"abc003\",\"order\":\"3\",\"fptrs\":[\"test_7\"],\"divs\":[]}
                  ]
       }
     }
@@ -129,7 +157,7 @@ def multiple_struct_maps_structure_to_json
                   {\"label\":\"Front\",\"order\":\"2\",\"fptrs\":[\"test_5\"],\"divs\":[]}
                  ]
       }
-    }    
+    }
   eos
   j.gsub(/\s+/, "")
 end


### PR DESCRIPTION
When constructing a default struct_map, if the object being added to the
struct map has a local_id, an ID attribute containing the local_id will
be added to the div element containing that object.