### PR TITLE
Ddr::Models::Base#attached_files_having_content implements indifferent access

### DIFF
--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -151,7 +151,7 @@ module Ddr::Models
     end
 
     def attached_files_having_content
-      Hash.new.tap do |h|
+      Hash.new.with_indifferent_access.tap do |h|
         attached_files.each do |file_id, file|
           h[file_id] = file if !file.destroyed? && file.has_content?
         end

--- a/lib/ddr/models/fixity_check_results.rb
+++ b/lib/ddr/models/fixity_check_results.rb
@@ -4,7 +4,7 @@ module Ddr::Models
   class FixityCheckResults < SimpleDelegator
 
     def initialize
-      super Hash.new
+      super Hash.new.with_indifferent_access
     end
 
     def success?

--- a/spec/models/indexing_spec.rb
+++ b/spec/models/indexing_spec.rb
@@ -61,7 +61,7 @@ module Ddr::Models
 
       its([Indexing::CONTENT_CREATE_DATE]) { is_expected.to eq "2016-01-22T21:50:33Z" }
       its([Indexing::ATTACHED_FILES_HAVING_CONTENT]) {
-        is_expected.to eq([:content])
+        is_expected.to eq(["content"])
       }
     end
 


### PR DESCRIPTION
Closes #640