### PR TITLE
Adds class method .build to Ddr::Index::Query

### DIFF
--- a/lib/ddr/index/query.rb
+++ b/lib/ddr/index/query.rb
@@ -16,6 +16,12 @@ module Ddr::Index
     delegate [:count, :docs, :ids, :each_id, :all] => :result
     delegate :params => :query_params
 
+    def self.build(*args, &block)
+      new.tap do |query|
+        query.build(*args, &block)
+      end
+    end
+
     def initialize(**args, &block)
       super(**args)
       if block_given?
@@ -58,8 +64,8 @@ module Ddr::Index
       QueryParams.new(self)
     end
 
-    def build(&block)
-      QueryBuilder.new(self, &block)
+    def build(*args, &block)
+      QueryBuilder.new(self, *args, &block)
       self
     end
 

--- a/lib/ddr/index/query_builder.rb
+++ b/lib/ddr/index/query_builder.rb
@@ -93,10 +93,10 @@ module Ddr::Index
 
     attr_reader :query
 
-    def initialize(query = nil, &block)
-      @query = query || Query.new
+    def initialize(*args, &block)
+      @query = args.first.is_a?(Query) ? args.shift : Query.new
       if block_given?
-        instance_eval &block
+        instance_exec(*args, &block)
       end
     end
 

--- a/spec/index/query_builder_spec.rb
+++ b/spec/index/query_builder_spec.rb
@@ -1,6 +1,5 @@
 module Ddr::Index
   RSpec.describe QueryBuilder do
-
     describe "DSL" do
       describe "id" do
         subject { described_class.new { id "test:1" } }
@@ -112,5 +111,14 @@ module Ddr::Index
       end
     end
 
+    describe "passing local vars" do
+      let(:local_var) { double(bar: "bar") }
+      subject {
+        described_class.new(local_var) { |foo| asc foo.bar }
+      }
+      specify {
+        expect(subject.query.sort).to eq [SortOrder.asc("bar")]
+      }
+    end
   end
 end

--- a/spec/index/query_spec.rb
+++ b/spec/index/query_spec.rb
@@ -1,37 +1,14 @@
 module Ddr::Index
   RSpec.describe Query do
-
-    describe "initialized with attributes" do
-      let(:id) { UniqueKeyField.instance }
-      let(:foo) { Field.new("foo") }
-      let(:spam) { Field.new("spam") }
-      let(:filter) { Filter.where(spam=>"eggs") }
-      let(:sort_order) { SortOrder.new(field: foo, order: "asc") }
-      let(:fields) { [id, foo, spam] }
-
+    describe ".build" do
+      let(:local1) { double(value: "foo:bar") }
+      let(:local2) { double(value: "foo") }
       subject {
-        described_class.new(q: "foo:bar",
-                            filters: [filter],
-                            fields: fields,
-                            sort: sort_order,
-                            rows: 50)
-      }
-
-      its(:to_s) {
-        is_expected.to eq "q=foo%3Abar&fq=spam%3Aeggs&fl=id%2Cfoo%2Cspam&sort=foo+asc&rows=50"
-      }
-      its(:params) {
-        is_expected.to eq({q: "foo:bar", fl: "id,foo,spam", fq: ["spam:eggs"], sort: "foo asc", rows: 50})
-      }
-    end
-
-    describe "initialized with a block" do
-      subject {
-        described_class.new do
-          q "foo:bar"
+        described_class.build(local1, local2) do |l1, l2|
+          q l1.value
           where "spam"=>"eggs"
           fields :id, "foo", "spam"
-          asc "foo"
+          asc l2.value
           limit 50
         end
       }
@@ -42,6 +19,51 @@ module Ddr::Index
       its(:params) {
         is_expected.to eq({q: "foo:bar", fl: "id,foo,spam", fq: ["spam:eggs"], sort: "foo asc", rows: 50})
       }
+    end
+
+    describe "initialization" do
+      describe "with attributes" do
+        let(:id) { UniqueKeyField.instance }
+        let(:foo) { Field.new("foo") }
+        let(:spam) { Field.new("spam") }
+        let(:filter) { Filter.where(spam=>"eggs") }
+        let(:sort_order) { SortOrder.new(field: foo, order: "asc") }
+        let(:fields) { [id, foo, spam] }
+
+        subject {
+          described_class.new(q: "foo:bar",
+                              filters: [filter],
+                              fields: fields,
+                              sort: sort_order,
+                              rows: 50)
+        }
+
+        its(:to_s) {
+          is_expected.to eq "q=foo%3Abar&fq=spam%3Aeggs&fl=id%2Cfoo%2Cspam&sort=foo+asc&rows=50"
+        }
+        its(:params) {
+          is_expected.to eq({q: "foo:bar", fl: "id,foo,spam", fq: ["spam:eggs"], sort: "foo asc", rows: 50})
+        }
+      end
+
+      describe "with a block" do
+        subject {
+          described_class.new do
+            q "foo:bar"
+            where "spam"=>"eggs"
+            fields :id, "foo", "spam"
+            asc "foo"
+            limit 50
+          end
+        }
+
+        its(:to_s) {
+          is_expected.to eq "q=foo%3Abar&fq=spam%3Aeggs&fl=id%2Cfoo%2Cspam&sort=foo+asc&rows=50"
+        }
+        its(:params) {
+          is_expected.to eq({q: "foo:bar", fl: "id,foo,spam", fq: ["spam:eggs"], sort: "foo asc", rows: 50})
+        }
+      end
     end
 
     describe "equality" do
@@ -65,6 +87,5 @@ module Ddr::Index
       end
       it { is_expected.to eq other }
     end
-
   end
 end


### PR DESCRIPTION
The change was made to provide a way to pass in local variables
for evaluation by QueryBuilder.  The latter class was altered to
use instance_exec instead of instance_eval.
Closes #639