### PR TITLE
Promote struct_map_pids private method to public; closes #618.

### DIFF
--- a/lib/ddr/models/solr_document.rb
+++ b/lib/ddr/models/solr_document.rb
@@ -239,6 +239,16 @@ module Ddr::Models
       self[Ddr::Index::Fields::WORKFLOW_STATE] == Ddr::Managers::WorkflowManager::PUBLISHED
     end
 
+    # For simplicity, initial implementation returns repository ID's only from top-level
+    # (i.e., not nested) div's.  This is done since we have not clarified what
+    # an _ordered_ list of repository ID's should look like if struct map contains nested
+    # div's.
+    def struct_map_ids(type='default')
+      struct_map(type)['divs'].map { |d| d['fptrs'].present? ? d['fptrs'].first : nil }.compact
+    rescue
+      []
+    end
+
     private
 
     def targets_query
@@ -272,21 +282,11 @@ module Ddr::Models
     end
 
     def struct_map_docs(type='default')
-      pids = struct_map_pids(type)
-      return [] if pids.empty?
-      raw_query = "id:(%s)" % pids.map { |p| "\"#{p}\"" }.join(" OR ")
+      ids = struct_map_ids(type)
+      return [] if ids.empty?
+      raw_query = "id:(%s)" % ids.map { |i| "\"#{i}\"" }.join(" OR ")
       q = Ddr::Index::Query.new { raw raw_query }
       q.docs.to_a
-    end
-
-    # For simplicity, initial implementation returns PID's only from top-level
-    # (i.e., not nested) div's.  This is done since we have not clarified what
-    # an _ordered_ list of PID's should look like if struct map contains nested
-    # div's.
-    def struct_map_pids(type='default')
-      struct_map(type)['divs'].map { |d| d['fptrs'].present? ? d['fptrs'].first : nil }.compact
-    rescue
-      []
     end
 
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -196,6 +196,24 @@ RSpec.describe SolrDocument, type: :model, contacts: true do
         end
       end
     end
+    describe "#struct_map_ids" do
+      context "no structural metadata" do
+        its(:struct_map_ids) { is_expected.to match([]) }
+      end
+      context "structural metadata" do
+        let(:struct_map) do
+          {"type"=>"default", "divs"=>
+              [{"id"=>"viccb010010010", "label"=>"1", "order"=>"1", "type"=>"Image", "fptrs"=>["test-6"], "divs"=>[]},
+               {"id"=>"viccb010020010", "label"=>"2", "order"=>"2", "type"=>"Image", "fptrs"=>["test-5"], "divs"=>[]},
+               {"id"=>"viccb010030010", "label"=>"3", "order"=>"3", "type"=>"Image", "fptrs"=>["test-7"], "divs"=>[]}]
+          }
+        end
+        before(:each) {
+          allow(subject).to receive(:struct_map) { struct_map }
+        }
+        its(:struct_map_ids) { is_expected.to match([ "test-6", "test-5", "test-7" ]) }
+      end
+    end
   end
 
   describe "#has_attached_file?" do


### PR DESCRIPTION
Also renames method to struct_map_ids.