### PR TITLE
Remove :license from Descriptive Metadata properties; closes #677.

### DIFF
--- a/lib/ddr/datastreams/descriptive_metadata_datastream.rb
+++ b/lib/ddr/datastreams/descriptive_metadata_datastream.rb
@@ -26,8 +26,11 @@ module Ddr
       vocabularies.each do |vocab|
         Ddr::Vocab::Vocabulary.property_terms(vocab).each do |term|
           term_name = Ddr::Vocab::Vocabulary.term_name(vocab, term)
-          property term_name, predicate: term do |index|
-            index.as *indexers_for(term_name)
+          # Do not include :license as a descriptive metadata property
+          unless term_name == :license
+            property term_name, predicate: term do |index|
+              index.as *indexers_for(term_name)
+            end
           end
         end
       end

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.4.13"
+    VERSION = "2.4.14"
   end
 end

--- a/spec/models/descriptive_metadata_datastream_spec.rb
+++ b/spec/models/descriptive_metadata_datastream_spec.rb
@@ -24,8 +24,8 @@ module Ddr
     RSpec.describe DescriptiveMetadataDatastream do
       context "terminology" do
         subject { described_class.term_names }
-        it "should have a term for each term name in the RDF::DC vocab" do
-          expect(subject).to include(*Ddr::Vocab::Vocabulary.term_names(RDF::DC))
+        it "should have a term for each term name in the RDF::DC vocab except :license" do
+          expect(subject).to include(*Ddr::Vocab::Vocabulary.term_names(RDF::DC)-[:license])
         end
         it "should have a term for each term name in the DukeTerms vocab" do
           expect(subject).to include(*Ddr::Vocab::Vocabulary.term_names(Ddr::Vocab::DukeTerms))
@@ -33,8 +33,9 @@ module Ddr
       end
       context "properties" do
         subject { described_class.properties.map { |prop| prop[1].predicate } }
-        it "should include all the RDF::DC predicates" do
-          expect(subject).to include(*Ddr::Vocab::Vocabulary.property_terms(RDF::DC))
+        it "should include all the RDF::DC predicates except http://purl.org/dc/terms/license" do
+          expected_predicates = Ddr::Vocab::Vocabulary.property_terms(RDF::DC).select { |p| p.to_s != 'http://purl.org/dc/terms/license' }
+          expect(subject).to include(*expected_predicates)
         end
         it "should include all the DukeTerms predicates" do
           expect(subject).to include(*Ddr::Vocab::Vocabulary.property_terms(Ddr::Vocab::DukeTerms))


### PR DESCRIPTION
:license is now only an Administrative Metadata property.