### PR TITLE
Adds :export ability to Collection

### DIFF
--- a/lib/ddr/auth/ability_definitions/collection_ability_definitions.rb
+++ b/lib/ddr/auth/ability_definitions/collection_ability_definitions.rb
@@ -6,6 +6,22 @@ module Ddr
         if member_of? Ddr::Auth.collection_creators_group
           can :create, ::Collection
         end
+        can :export, ::Collection do |obj|
+          has_policy_permission?(obj, Permissions::READ)
+        end
+      end
+
+      private
+
+      def policy_permissions(obj)
+        obj.roles
+          .in_policy_scope
+          .agent(agents)
+          .permissions
+      end
+
+      def has_policy_permission?(obj, perm)
+        policy_permissions(obj).include?(perm)
       end
 
     end

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.4.14"
+    VERSION = "2.4.15"
   end
 end


### PR DESCRIPTION
The ability is granted if the auth context agents have a policy scope role
that grants the :read permission.

Version 2.4.15