### PR TITLE
Changes event name in Ddr::Models::Base#notify_save

### DIFF
--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -2,8 +2,6 @@ module Ddr
   module Models
     class Base < ActiveFedora::Base
 
-      SAVE = "save.base.models.ddr"
-
       include Describable
       include Governable
       include AccessControllable
@@ -113,9 +111,8 @@ module Ddr
       private
 
       def notify_save
-        ActiveSupport::Notifications.instrument(SAVE,
+        ActiveSupport::Notifications.instrument("save.#{self.class.to_s.underscore}",
                                                 pid: pid,
-                                                model: self.class.to_s,
                                                 changes: changes,
                                                 created: new_record?) do |payload|
           yield

--- a/spec/support/shared_examples_for_ddr_models.rb
+++ b/spec/support/shared_examples_for_ddr_models.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "a DDR model" do
   describe "notification on save" do
     let(:events) { [] }
     before {
-      @subscriber = ActiveSupport::Notifications.subscribe(Ddr::Models::Base::SAVE) do |name, start, finish, id, payload|
+      @subscriber = ActiveSupport::Notifications.subscribe("save.#{described_class.to_s.underscore}") do |name, start, finish, id, payload|
         events << payload
       end
     }
@@ -24,11 +24,9 @@ RSpec.shared_examples "a DDR model" do
       expect(events.first[:changes]).to eq({"title"=>[[], ["My Title Changed"]]})
       expect(events.first[:created]).to be true
       expect(events.first[:pid]).to eq(subject.pid)
-      expect(events.first[:model]).to eq(subject.class.name)
       expect(events.last[:changes]).to eq({"title"=>[["My Title Changed"], ["My Title Changed Again"]]})
       expect(events.last[:created]).to be false
       expect(events.last[:pid]).to eq(subject.pid)
-      expect(events.last[:model]).to eq(subject.class.name)
     end
   end
 


### PR DESCRIPTION
Now putting model in event name instead of payload, e.g.
"save.collection".