### PR TITLE
Adds a new event for deaccessioning.

### DIFF
--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -16,3 +16,9 @@ ActiveSupport::Notifications.subscribe(Ddr::Notifications::UPDATE, Ddr::Events::
 
 # Deletion
 ActiveSupport::Notifications.subscribe(Ddr::Notifications::DELETION, Ddr::Events::DeletionEvent)
+ActiveSupport::Notifications.subscribe(/destroy\.\w+/, Ddr::Events::DeletionEvent)
+ActiveSupport::Notifications.subscribe(/destroy\.\w+/, Ddr::Jobs::PermanentId::MakeUnavailable)
+
+# Deaccession
+ActiveSupport::Notifications.subscribe(/deaccession\.\w+/, Ddr::Events::DeaccessionEvent)
+ActiveSupport::Notifications.subscribe(/deaccession\.\w+/, Ddr::Jobs::PermanentId::MakeUnavailable)

--- a/db/migrate/20161021201011_add_permanent_id_to_events.rb
+++ b/db/migrate/20161021201011_add_permanent_id_to_events.rb
@@ -1,0 +1,8 @@
+class AddPermanentIdToEvents < ActiveRecord::Migration
+  def change
+    change_table :events do |t|
+      t.string :permanent_id
+      t.index :permanent_id
+    end
+  end
+end

--- a/lib/ddr/events.rb
+++ b/lib/ddr/events.rb
@@ -4,6 +4,7 @@ module Ddr
 
     autoload :Event
     autoload :CreationEvent
+    autoload :DeaccessionEvent
     autoload :DeletionEvent
     autoload :FixityCheckEvent
     autoload :IngestionEvent

--- a/lib/ddr/events/deaccession_event.rb
+++ b/lib/ddr/events/deaccession_event.rb
@@ -1,0 +1,8 @@
+module Ddr::Events
+  class DeaccessionEvent < Event
+    include PreservationEventBehavior
+
+    self.description = "Object deaccessioned"
+    self.preservation_event_type = :dea
+  end
+end

--- a/lib/ddr/jobs/permanent_id.rb
+++ b/lib/ddr/jobs/permanent_id.rb
@@ -11,6 +11,18 @@ module Ddr
       end
 
       class MakeUnavailable < Job
+        def self.call(*args)
+          event = ActiveSupport::Notifications::Event.new(*args)
+          id = event.payload[:permanent_id]
+          reason = case event.name.split(".").first
+                   when "destroy"
+                     "deleted"
+                   when "deaccession"
+                     "deaccessioned"
+                   end
+          Resque.enqueue(self, id, reason) if id.present?
+        end
+
         def self.perform(id, reason = nil)
           identifier = Ezid::Identifier.find(id)
           identifier.unavailable!(reason)

--- a/lib/ddr/models/has_admin_metadata.rb
+++ b/lib/ddr/models/has_admin_metadata.rb
@@ -28,7 +28,6 @@ module Ddr::Models
       delegate :publish!, :unpublish!, :published?, to: :workflow
 
       after_create :assign_permanent_id!, if: "Ddr::Models.auto_assign_permanent_ids"
-      around_destroy :update_permanent_id_on_destroy, if: "permanent_id.present?"
     end
 
     def permanent_id_manager

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150713171838) do
+ActiveRecord::Schema.define(version: 20161021201011) do
 
   create_table "events", force: true do |t|
     t.datetime "event_date_time"
@@ -27,10 +27,12 @@ ActiveRecord::Schema.define(version: 20150713171838) do
     t.text     "detail"
     t.text     "exception",       limit: 65535
     t.string   "user_key"
+    t.string   "permanent_id"
   end
 
   add_index "events", ["event_date_time"], name: "index_events_on_event_date_time"
   add_index "events", ["outcome"], name: "index_events_on_outcome"
+  add_index "events", ["permanent_id"], name: "index_events_on_permanent_id"
   add_index "events", ["pid"], name: "index_events_on_pid"
   add_index "events", ["type"], name: "index_events_on_type"
 

--- a/spec/models/events_spec.rb
+++ b/spec/models/events_spec.rb
@@ -68,5 +68,18 @@ module Ddr
         expect(subject.display_type).to eq "Deletion"
       end
     end
+
+    RSpec.describe DeaccessionEvent, type: :model, events: true do
+      it_behaves_like "an event"
+      it_behaves_like "a preservation-related event"
+      it "should have a display type" do
+        expect(subject.display_type).to eq "Deaccession"
+      end
+
+      describe "permanent id" do
+        subject { described_class.new(pid: "test:1", permanent_id: "ark:/99999/fk4zzz") }
+        its(:permanent_id) { is_expected.to eq("ark:/99999/fk4zzz") }
+      end
+    end
   end
 end

--- a/spec/models/has_admin_metadata_spec.rb
+++ b/spec/models/has_admin_metadata_spec.rb
@@ -73,6 +73,13 @@ module Ddr::Models
                    .to("unavailable | deleted")
           end
         end
+        describe "object deaccession" do
+          it "marks the identifier as unavailable" do
+            expect { subject.deaccession }
+              .to change(identifier, :status)
+                   .to("unavailable | deaccessioned")
+          end
+        end
       end
 
       describe "events" do


### PR DESCRIPTION
New event type: `Ddr::Events::Deaccession`.
New instance method for Ddr::Models::Base: `deaccession`.
Callbacks, notifications, and subscriptions adjusted for deletion
events (triggered by `destroy`).