### PR TITLE
Removed redundant code related to sign out.

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,9 +10,4 @@ class Users::SessionsController < Devise::SessionsController
     end
   end
 
-  def after_sign_out_path_for(scope)
-    return Ddr::Auth.sso_logout_url if Ddr::Auth.require_shib_user_authn
-    super
-  end
-
 end

--- a/lib/ddr/auth.rb
+++ b/lib/ddr/auth.rb
@@ -91,10 +91,6 @@ module Ddr
       false
     end
 
-    mattr_accessor :sso_logout_url do
-      "/Shibboleth.sso/Logout?return=https://shib.oit.duke.edu/cgi-bin/logout.pl"
-    end
-
     # Grouper gateway implementation
     mattr_accessor :grouper_gateway do
       GrouperGateway


### PR DESCRIPTION
After sign out redirection on servers where Shib authn is required is
handled in Apache conf.
Removed override of `Users::SessionsController#after_sign_out_path_for`
and `Ddr::Auth.sso_logout_url` accessor.

Upgrade note: Remove references to `Ddr::Auth.sso_logout_url` in
local files (e.g., production.rb) if necessary.