### PR TITLE
Remove use of 'open3' in derivatives generation; addresses DDR-294.

### DIFF
--- a/lib/ddr/actions/virus_check.rb
+++ b/lib/ddr/actions/virus_check.rb
@@ -1,4 +1,3 @@
-require "open3"
 require "ostruct"
 require "shellwords"
 

--- a/lib/ddr/derivatives/generator.rb
+++ b/lib/ddr/derivatives/generator.rb
@@ -5,8 +5,6 @@ module Ddr
 
       attr_reader :source, :output, :options
 
-      GeneratorResult = Struct.new(:stdout, :stderr, :status)
-
       def initialize source, output, options=nil
         raise ArgumentError, "Source must be a File or path to a file" unless Ddr::Utils.file_or_path?(source)
         raise ArgumentError, "Output must be a File or path to a file" unless Ddr::Utils.file_or_path?(output)

--- a/lib/ddr/derivatives/png_generator.rb
+++ b/lib/ddr/derivatives/png_generator.rb
@@ -1,5 +1,3 @@
-require 'open3'
-
 module Ddr
   module Derivatives
     class PngGenerator < Generator
@@ -10,8 +8,8 @@ module Ddr
 
       def generate
         command = "convert #{Ddr::Utils.file_path(source)}[0] #{options} png:#{Ddr::Utils.file_path(output)}"
-        out, err, s = Open3.capture3(command)
-        GeneratorResult.new(out, err, s)
+        `#{command}`
+        $?.exitstatus
       end
 
     end

--- a/lib/ddr/derivatives/ptif_generator.rb
+++ b/lib/ddr/derivatives/ptif_generator.rb
@@ -1,5 +1,3 @@
-require 'open3'
-
 module Ddr
   module Derivatives
     class PtifGenerator < Generator
@@ -27,19 +25,20 @@ module Ddr
 
       def run_generator(source_to_use)
         command = "vips im_vips2tiff #{Ddr::Utils.file_path(source_to_use)} #{Ddr::Utils.file_path(output)}:#{options}"
-        out, err, s = Open3.capture3(command)
-        GeneratorResult.new(out, err, s)
+        `#{command}`
+        $?.exitstatus
       end
 
       def make_8_bit(tempdir)
         temp_8_bit = File.new(File.join(tempdir, "temp_8_bit.v"), 'wb')
         command = "vips im_msb #{Ddr::Utils.file_path(source)} #{Ddr::Utils::file_path(temp_8_bit)}"
-        out, err, s = Open3.capture3(command)
-        if s.success?
+        `#{command}`
+        exitstatus = $?.exitstatus
+        if exitstatus == 0
           return temp_8_bit
         else
           raise Ddr::Models::DerivativeGenerationFailure,
-                  "Error converting #{Ddr::Utils.file_path(source)} to 8-bit: #{err}"
+                  "Error converting #{Ddr::Utils.file_path(source)} to 8-bit"
         end
       end
 

--- a/lib/ddr/managers/derivatives_manager.rb
+++ b/lib/ddr/managers/derivatives_manager.rb
@@ -56,17 +56,16 @@ module Ddr
           tempdir = FileUtils.mkdir(tempdir_path).first
           generator_source = create_source_file(tempdir)
           generator_output = File.new(File.join(tempdir, "output.out"), 'wb')
-          results = derivative.generator.new(generator_source.path, generator_output.path, derivative.options).generate
+          exitstatus = derivative.generator.new(generator_source.path, generator_output.path, derivative.options).generate
           generator_source.close unless generator_source.closed?
-          if results.status.success?
+          if exitstatus == 0
             generator_output = File.open(generator_output, 'rb')
             object.reload if object.persisted?
             object.add_file generator_output, derivative.datastream, mime_type: derivative.generator.output_mime_type
             object.save!
           else
-            Rails.logger.error results.stderr
             raise Ddr::Models::DerivativeGenerationFailure,
-                    "Failure generating #{derivative.name} for #{object.pid}: #{results.stderr}"
+                    "Failure generating #{derivative.name} for #{object.pid}"
           end
           generator_output.close unless generator_output.closed?
         ensure


### PR DESCRIPTION
Also remove unneeded 'open3' require in lib/ddr/actions/virus_check.rb.