### PR TITLE
Hotfix v2.5.2

### DIFF
--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -93,7 +93,7 @@ module Ddr
     mattr_accessor :auto_assign_permanent_ids
 
     mattr_accessor :permanent_id_target_url_base do
-      "https://repository.lib.duke.edu/id/"
+      "https://repository.duke.edu/id/"
     end
 
     # Home directory for FITS

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.5.1"
+    VERSION = "2.5.2"
   end
 end


### PR DESCRIPTION
Updates permanent ID target base URL (cherry-picked
from 7b424deb3fe08eb00e365931151e6364d69ddbfc).