### PR TITLE
Hotfix v2.5.3

### DIFF
--- a/lib/ddr/managers/permanent_id_manager.rb
+++ b/lib/ddr/managers/permanent_id_manager.rb
@@ -10,7 +10,7 @@ module Ddr
     #
     class PermanentIdManager
 
-      PERMANENT_URL_BASE = "http://id.library.duke.edu/"
+      PERMANENT_URL_BASE = "https://idn.duke.edu/"
       ASSIGN_EVENT_SUMMARY = "Permanent ID assignment"
       SOFTWARE = Ezid::Client.version
       FCREPO3_PID = "fcrepo3.pid"

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.5.2"
+    VERSION = "2.5.3"
   end
 end


### PR DESCRIPTION
Updates permanent URL base to https://idn.duke.edu/ (cherry-picked
from 1c4fea5664d8d203717b7977565d93b1cad9d645).
Contributes to DDR-295.