### PR TITLE
Adds #unpublished? method to WorkflowManager.

### DIFF
--- a/lib/ddr/managers/workflow_manager.rb
+++ b/lib/ddr/managers/workflow_manager.rb
@@ -9,6 +9,9 @@ module Ddr
         object.workflow_state == PUBLISHED
       end
 
+      def unpublished?
+        object.workflow_state == UNPUBLISHED
+      end
 
       def publish!(include_descendants: true)
         unless published?

--- a/lib/ddr/models/has_admin_metadata.rb
+++ b/lib/ddr/models/has_admin_metadata.rb
@@ -26,7 +26,8 @@ module Ddr::Models
                      datastream: "adminMetadata",
                      multiple: false
 
-      delegate :publish!, :unpublish!, :published?, to: :workflow
+      delegate :publish!, :unpublish!, :published?, :unpublished?,
+               to: :workflow
 
       after_create :assign_permanent_id!, if: "Ddr::Models.auto_assign_permanent_ids"
     end

--- a/spec/models/has_admin_metadata_spec.rb
+++ b/spec/models/has_admin_metadata_spec.rb
@@ -122,17 +122,34 @@ module Ddr::Models
       end
 
       describe "#published?" do
+        subject { collection }
         context "object is published" do
-          before { allow(collection).to receive(:workflow_state) { Ddr::Managers::WorkflowManager::PUBLISHED } }
-          it "should return true" do
-            expect(collection).to be_published
-          end
+          before { subject.workflow_state = Ddr::Managers::WorkflowManager::PUBLISHED }
+          it { is_expected.to be_published }
         end
-        context "object is not published" do
-          before { allow(collection).to receive(:workflow_state) { nil } }
-          it "should return false" do
-            expect(collection).not_to be_published
-          end
+        context "object workflow is not set" do
+          before { subject.workflow_state = nil }
+          it { is_expected.not_to be_published }
+        end
+        context "object is unpublished" do
+          before { subject.workflow_state = Ddr::Managers::WorkflowManager::UNPUBLISHED }
+          it { is_expected.not_to be_published }
+        end
+      end
+
+      describe "#unpublished?" do
+        subject { collection }
+        context "object is published" do
+          before { subject.workflow_state = Ddr::Managers::WorkflowManager::PUBLISHED }
+          it { is_expected.not_to be_unpublished }
+        end
+        context "object is unpublished" do
+          before { subject.workflow_state = Ddr::Managers::WorkflowManager::UNPUBLISHED }
+          it { is_expected.to be_unpublished }
+        end
+        context "object workflow is not set" do
+          before { subject.workflow_state = nil }
+          it { is_expected.not_to be_unpublished }
         end
       end
 


### PR DESCRIPTION
Purpose is to distinguish between unset (initial) workflow state
and workflow state specifically set to "unpublished".