### PR TITLE
Adds after_create notification to Ddr::Models::Base

### DIFF
--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -89,9 +89,6 @@ module Ddr
     # Image server URL
     mattr_accessor :image_server_url
 
-    # Whether permanent IDs should be automatically assigned on create
-    mattr_accessor :auto_assign_permanent_ids
-
     mattr_accessor :permanent_id_target_url_base do
       "https://repository.duke.edu/id/"
     end

--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -23,6 +23,7 @@ module Ddr
       deprecation_deprecate *(Hydra::AccessControls::Permissions.public_instance_methods)
 
       around_save :notify_save
+      after_create :notify_create
       around_deaccession :notify_deaccession
       around_destroy :notify_destroy
 
@@ -126,6 +127,11 @@ module Ddr
                                                 created: new_record?) do |payload|
           yield
         end
+      end
+
+      def notify_create
+        ActiveSupport::Notifications.instrument("create.#{self.class.to_s.underscore}",
+                                                pid: pid)
       end
 
       def notify_deaccession

--- a/lib/ddr/models/has_admin_metadata.rb
+++ b/lib/ddr/models/has_admin_metadata.rb
@@ -28,8 +28,6 @@ module Ddr::Models
 
       delegate :publish!, :unpublish!, :published?, :unpublished?,
                to: :workflow
-
-      after_create :assign_permanent_id!, if: "Ddr::Models.auto_assign_permanent_ids"
     end
 
     def permanent_id_manager
@@ -49,6 +47,9 @@ module Ddr::Models
     end
 
     def assign_permanent_id!
+      Deprecation.warn(self.class, "`assign_permanent_id!` is deprecated and will be removed from ddr-models 3.0." \
+                                   " Use `PermanentId.assign!(obj)` in dul-hydra instead" \
+                                   " (called from #{caller.first}).")
       permanent_id_manager.assign_later
     end
 

--- a/spec/models/has_admin_metadata_spec.rb
+++ b/spec/models/has_admin_metadata_spec.rb
@@ -12,40 +12,6 @@ module Ddr::Models
           expect(subject.permanent_id_manager).to receive(:assign_later) { nil }
           subject.assign_permanent_id!
         end
-        context "when the object is created (first saved)" do
-          context "and auto-assignment is enabled" do
-            before { allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { true } }
-            it "should assign a permanent id" do
-              expect(subject).to receive(:assign_permanent_id!) { nil }
-              subject.save!
-            end
-          end
-          context "and auto-assignment is disabled" do
-            before { allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { false } }
-            it "should not assign a permanent id" do
-              expect(subject).not_to receive(:assign_permanent_id!)
-              subject.save!
-            end
-          end
-        end
-        context "when saved" do
-          context "and auto-assignment is enabled" do
-            before { allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { true } }
-            it "should assign a permanent id once" do
-              expect(subject).to receive(:assign_permanent_id!).once { nil }
-              subject.save!
-              subject.title = ["New Title"]
-              subject.save!
-            end
-          end
-          context "and auto-assignment is disabled" do
-            before { allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { false } }
-            it "should not assign a permanent id" do
-              expect(subject).not_to receive(:assign_permanent_id!)
-              subject.save!
-            end
-          end
-        end
       end
 
       describe "lifecycle" do
@@ -54,17 +20,9 @@ module Ddr::Models
           Ezid::MockIdentifier.create(subject.permanent_id_manager.default_metadata)
         }
         before do
-          allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { false }
           allow(Ezid::Identifier).to receive(:find).with(identifier.id) { identifier }
           subject.permanent_id = identifier.id
           subject.save!
-        end
-        describe "identifier creation" do
-          it "sets default metadata" do
-            expect(identifier.profile).to eq("dc")
-            expect(identifier.export).to eq("no")
-            expect(identifier["fcrepo3.pid"]).to eq(subject.pid)
-          end
         end
         describe "object destruction" do
           it "marks the identifier as unavailable" do
@@ -82,235 +40,209 @@ module Ddr::Models
         end
       end
 
-      describe "events" do
-        before { allow(Ddr::Models).to receive(:auto_assign_permanent_ids) { true } }
-        context "when the operation succeeds" do
-          let!(:mock_identifier) { Ezid::MockIdentifier.new(id: "ark:/99999/fk4zzz",
-                                                            metadata: "_target: http://example.com") }
-          before do
-            allow(Ezid::Identifier).to receive(:create) { mock_identifier }
-            allow(Ezid::Identifier).to receive(:find) { mock_identifier }
-            allow(subject.permanent_id_manager).to receive(:record) { mock_identifier }
+      describe "workflow" do
+
+        let(:collection) { FactoryGirl.create(:collection) }
+        let(:item) { FactoryGirl.create(:item) }
+        let(:component) { FactoryGirl.create(:component) }
+        before do
+          item.parent = collection
+          item.save!
+          component.parent = item
+          component.save!
+        end
+
+        describe "#published?" do
+          subject { collection }
+          context "object is published" do
+            before { subject.workflow_state = Ddr::Managers::WorkflowManager::PUBLISHED }
+            it { is_expected.to be_published }
           end
-          it "should create a success event" do
-            expect { subject.save }.to change { subject.update_events.count }.by(1)
+          context "object workflow is not set" do
+            before { subject.workflow_state = nil }
+            it { is_expected.not_to be_published }
+          end
+          context "object is unpublished" do
+            before { subject.workflow_state = Ddr::Managers::WorkflowManager::UNPUBLISHED }
+            it { is_expected.not_to be_published }
           end
         end
-        context "when there's an exception" do
-          before { allow(Ezid::Identifier).to receive(:create).and_raise(Ezid::Error) }
-          it "should create a failure event" do
-            begin
-              subject.save
-            rescue Ezid::Error
+
+        describe "#unpublished?" do
+          subject { collection }
+          context "object is published" do
+            before { subject.workflow_state = Ddr::Managers::WorkflowManager::PUBLISHED }
+            it { is_expected.not_to be_unpublished }
+          end
+          context "object is unpublished" do
+            before { subject.workflow_state = Ddr::Managers::WorkflowManager::UNPUBLISHED }
+            it { is_expected.to be_unpublished }
+          end
+          context "object workflow is not set" do
+            before { subject.workflow_state = nil }
+            it { is_expected.not_to be_unpublished }
+          end
+        end
+
+        describe "#publish!" do
+          context "do not include descendants" do
+            it "should publish and persist the object" do
+              collection.publish!(include_descendants: false)
+              expect(collection.reload).to be_published
+              expect(item.reload).not_to be_published
+              expect(component.reload).not_to be_published
             end
-            expect(subject.update_events.last).to be_failure
+          end
+          context "do include descendants" do
+            it "should publish and persist the object and descendants" do
+              collection.publish!
+              expect(collection.reload).to be_published
+              expect(item.reload).to be_published
+              expect(component.reload).to be_published
+            end
           end
         end
-      end
-    end
 
-    describe "workflow" do
-
-      let(:collection) { FactoryGirl.create(:collection) }
-      let(:item) { FactoryGirl.create(:item) }
-      let(:component) { FactoryGirl.create(:component) }
-      before do
-        item.parent = collection
-        item.save!
-        component.parent = item
-        component.save!
-      end
-
-      describe "#published?" do
-        subject { collection }
-        context "object is published" do
-          before { subject.workflow_state = Ddr::Managers::WorkflowManager::PUBLISHED }
-          it { is_expected.to be_published }
-        end
-        context "object workflow is not set" do
-          before { subject.workflow_state = nil }
-          it { is_expected.not_to be_published }
-        end
-        context "object is unpublished" do
-          before { subject.workflow_state = Ddr::Managers::WorkflowManager::UNPUBLISHED }
-          it { is_expected.not_to be_published }
-        end
-      end
-
-      describe "#unpublished?" do
-        subject { collection }
-        context "object is published" do
-          before { subject.workflow_state = Ddr::Managers::WorkflowManager::PUBLISHED }
-          it { is_expected.not_to be_unpublished }
-        end
-        context "object is unpublished" do
-          before { subject.workflow_state = Ddr::Managers::WorkflowManager::UNPUBLISHED }
-          it { is_expected.to be_unpublished }
-        end
-        context "object workflow is not set" do
-          before { subject.workflow_state = nil }
-          it { is_expected.not_to be_unpublished }
-        end
-      end
-
-      describe "#publish!" do
-        context "do not include descendants" do
-          it "should publish and persist the object" do
-            collection.publish!(include_descendants: false)
-            expect(collection.reload).to be_published
+        describe "#unpublish!" do
+          before { collection.publish! }
+          it "should unpublish and persist the object and descendants" do
+            collection.unpublish!
+            expect(collection.reload).not_to be_published
             expect(item.reload).not_to be_published
             expect(component.reload).not_to be_published
           end
         end
-        context "do include descendants" do
-          it "should publish and persist the object and descendants" do
-            collection.publish!
-            expect(collection.reload).to be_published
-            expect(item.reload).to be_published
-            expect(component.reload).to be_published
+      end
+
+      describe "roles" do
+
+        subject { FactoryGirl.build(:item) }
+
+        describe "#copy_resource_roles_from" do
+          let(:other) { FactoryGirl.build(:collection) }
+          let(:resource_roles) do
+            [ FactoryGirl.build(:role, :viewer, :public, :resource),
+              FactoryGirl.build(:role, :editor, :group, :resource) ]
+          end
+          let(:policy_roles) do
+            [ FactoryGirl.build(:role, :curator, :person, :policy) ]
+          end
+          before do
+            other.roles.grant *resource_roles
+            other.roles.grant *policy_roles
+            subject.copy_resource_roles_from(other)
+          end
+          its(:roles) { should include(*resource_roles) }
+          its(:roles) { should_not include(*policy_roles) }
+        end
+
+        describe "#grant_roles_to_creator" do
+          let(:user) { FactoryGirl.build(:user) }
+          before { subject.grant_roles_to_creator(user) }
+          its(:roles) { should include(Ddr::Auth::Roles::Role.build(type: "Editor", agent: user.agent, scope: "resource")) }
+        end
+
+        describe "persistence" do
+          let(:role) { FactoryGirl.build(:role, :downloader, :public) }
+          it "should persist the role information" do
+            subject.roles.grant role
+            subject.save!
+            subject.reload
+            expect(subject.roles).to contain_exactly(role)
           end
         end
+
       end
 
-      describe "#unpublish!" do
-        before { collection.publish! }
-        it "should unpublish and persist the object and descendants" do
-          collection.unpublish!
-          expect(collection.reload).not_to be_published
-          expect(item.reload).not_to be_published
-          expect(component.reload).not_to be_published
-        end
-      end
-    end
+      describe "contacts" do
 
-    describe "roles" do
+        subject { FactoryGirl.build(:item) }
 
-      subject { FactoryGirl.build(:item) }
-
-      describe "#copy_resource_roles_from" do
-        let(:other) { FactoryGirl.build(:collection) }
-        let(:resource_roles) do
-          [ FactoryGirl.build(:role, :viewer, :public, :resource),
-            FactoryGirl.build(:role, :editor, :group, :resource) ]
-        end
-        let(:policy_roles) do
-          [ FactoryGirl.build(:role, :curator, :person, :policy) ]
-        end
         before do
-          other.roles.grant *resource_roles
-          other.roles.grant *policy_roles
-          subject.copy_resource_roles_from(other)
+          allow(Ddr::Models::Contact).to receive(:get).with(:find, slug: 'xa') do
+            {'id'=>1, 'slug'=>'xa', 'name'=>'Contact A', 'short_name'=>'A'}
+          end
+          allow(Ddr::Models::Contact).to receive(:get).with(:find, slug: 'yb') do
+            {'id'=>1, 'slug'=>'yb', 'name'=>'Contact B', 'short_name'=>'B'}
+          end
         end
-        its(:roles) { should include(*resource_roles) }
-        its(:roles) { should_not include(*policy_roles) }
+        describe "#research_help" do
+          before { subject.research_help_contact = 'yb' }
+          it "should return the appropriate contact" do
+            expect(subject.research_help.slug).to eq('yb')
+          end
+        end
       end
 
-      describe "#grant_roles_to_creator" do
-        let(:user) { FactoryGirl.build(:user) }
-        before { subject.grant_roles_to_creator(user) }
-        its(:roles) { should include(Ddr::Auth::Roles::Role.build(type: "Editor", agent: user.agent, scope: "resource")) }
-      end
+      describe "locking" do
 
-      describe "persistence" do
-        let(:role) { FactoryGirl.build(:role, :downloader, :public) }
-        it "should persist the role information" do
-          subject.roles.grant role
-          subject.save!
-          subject.reload
-          expect(subject.roles).to contain_exactly(role)
+        subject { FactoryGirl.build(:item) }
+
+        describe "#locked?" do
+          context "object is locked" do
+            before { subject.is_locked = true }
+            context "repository is locked" do
+              before { Ddr::Models.repository_locked = true }
+              after { Ddr::Models.repository_locked = false }
+              it "should be true" do
+                expect(subject.locked?).to be true
+              end
+            end
+            context "repository is not locked" do
+              it "should be true" do
+                expect(subject.locked?).to be true
+              end
+            end
+          end
+          context "object is not locked" do
+            before { subject.is_locked = false }
+            context "repository is locked" do
+              before { Ddr::Models.repository_locked = true }
+              after { Ddr::Models.repository_locked = false }
+              it "should be true" do
+                expect(subject.locked?).to be true
+              end
+            end
+            context "repository is not locked" do
+              it "should be false" do
+                expect(subject.locked?).to be false
+              end
+            end
+          end
         end
+
+        describe "lock" do
+          it "should lock the object" do
+            expect { subject.lock }.to change(subject, :locked?).from(false).to(true)
+          end
+        end
+
+        describe "unlock" do
+          before { subject.lock }
+          it "should unlock the object" do
+            expect { subject.unlock }.to change(subject, :locked?).from(true).to(false)
+          end
+        end
+
+        describe "lock!" do
+          it "should lock and save the object" do
+            subject.lock!
+            subject.reload
+            expect(subject.locked?).to be true
+          end
+        end
+
+        describe "unlock!" do
+          before { subject.lock! }
+          it "should unlock and save the object" do
+            subject.unlock!
+            subject.reload
+            expect(subject.locked?).to be false
+          end
+        end
+
       end
 
     end
-
-    describe "contacts" do
-
-      subject { FactoryGirl.build(:item) }
-
-      before do
-        allow(Ddr::Models::Contact).to receive(:get).with(:find, slug: 'xa') do
-          {'id'=>1, 'slug'=>'xa', 'name'=>'Contact A', 'short_name'=>'A'}
-        end
-        allow(Ddr::Models::Contact).to receive(:get).with(:find, slug: 'yb') do
-          {'id'=>1, 'slug'=>'yb', 'name'=>'Contact B', 'short_name'=>'B'}
-        end
-      end
-      describe "#research_help" do
-        before { subject.research_help_contact = 'yb' }
-        it "should return the appropriate contact" do
-          expect(subject.research_help.slug).to eq('yb')
-        end
-      end
-    end
-
-    describe "locking" do
-
-      subject { FactoryGirl.build(:item) }
-
-      describe "#locked?" do
-        context "object is locked" do
-          before { subject.is_locked = true }
-          context "repository is locked" do
-            before { Ddr::Models.repository_locked = true }
-            after { Ddr::Models.repository_locked = false }
-            it "should be true" do
-              expect(subject.locked?).to be true
-            end
-          end
-          context "repository is not locked" do
-            it "should be true" do
-              expect(subject.locked?).to be true
-            end
-          end
-        end
-        context "object is not locked" do
-          before { subject.is_locked = false }
-          context "repository is locked" do
-            before { Ddr::Models.repository_locked = true }
-            after { Ddr::Models.repository_locked = false }
-            it "should be true" do
-              expect(subject.locked?).to be true
-            end
-          end
-          context "repository is not locked" do
-            it "should be false" do
-              expect(subject.locked?).to be false
-            end
-          end
-        end
-      end
-
-      describe "lock" do
-        it "should lock the object" do
-          expect { subject.lock }.to change(subject, :locked?).from(false).to(true)
-        end
-      end
-
-      describe "unlock" do
-        before { subject.lock }
-        it "should unlock the object" do
-          expect { subject.unlock }.to change(subject, :locked?).from(true).to(false)
-        end
-      end
-
-      describe "lock!" do
-        it "should lock and save the object" do
-          subject.lock!
-          subject.reload
-          expect(subject.locked?).to be true
-        end
-      end
-
-      describe "unlock!" do
-        before { subject.lock! }
-        it "should unlock and save the object" do
-          subject.unlock!
-          subject.reload
-          expect(subject.locked?).to be false
-        end
-      end
-
-    end
-
   end
 end

--- a/spec/support/shared_examples_for_ddr_models.rb
+++ b/spec/support/shared_examples_for_ddr_models.rb
@@ -30,6 +30,26 @@ RSpec.shared_examples "a DDR model" do
     end
   end
 
+  describe "notification on create" do
+    let(:events) { [] }
+    before {
+      @subscriber = ActiveSupport::Notifications.subscribe("create.#{described_class.to_s.underscore}") do |name, start, finish, id, payload|
+        events << payload
+      end
+    }
+    after {
+      ActiveSupport::Notifications.unsubscribe(@subscriber)
+    }
+    it "happens after create" do
+      subject.title = [ "My Title Changed" ]
+      subject.save
+      subject.title = [ "My Title Changed Again" ]
+      subject.save
+      expect(events.size).to eq(1)
+      expect(events.first[:pid]).to eq(subject.pid)
+    end
+  end
+
   describe "events" do
     before {
       subject.permanent_id = "ark:/99999/fk4zzz"


### PR DESCRIPTION
- Deprecates `Ddr::Models::HasAdminMetadata#assign_permanent_id!`.
- Removes after_create callback to assign permanent id (if auto-assign
enabled)
- Removes config setting `Ddr::Models.auto_assign_permanent_ids`.

Upgrade notes:
- Check local config files and remove references to
`Ddr::Models.auto_assign_permanent_ids`.