### PR TITLE
Moves PermanentId class from DulHydra to Ddr::Models.

### DIFF
--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -13,10 +13,16 @@ ActiveSupport::Notifications.subscribe(Ddr::Notifications::CREATION, Ddr::Events
 
 # Update
 ActiveSupport::Notifications.subscribe(Ddr::Notifications::UPDATE, Ddr::Events::UpdateEvent)
+ActiveSupport::Notifications.subscribe("assign.permanent_id", Ddr::Events::UpdateEvent)
 
 # Deletion
 ActiveSupport::Notifications.subscribe(Ddr::Notifications::DELETION, Ddr::Events::DeletionEvent)
 ActiveSupport::Notifications.subscribe(/destroy\.\w+/, Ddr::Events::DeletionEvent)
+ActiveSupport::Notifications.subscribe(/destroy\.\w+/, Ddr::Models::PermanentId)
 
 # Deaccession
 ActiveSupport::Notifications.subscribe(/deaccession\.\w+/, Ddr::Events::DeaccessionEvent)
+ActiveSupport::Notifications.subscribe(/deaccession\.\w+/, Ddr::Models::PermanentId)
+
+# Workflow
+ActiveSupport::Notifications.subscribe(/workflow/, Ddr::Models::PermanentId)

--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -63,6 +63,7 @@ module Ddr
     autoload :HasThumbnail
     autoload :Indexing
     autoload :NotFoundError, 'ddr/models/error'
+    autoload :PermanentId
     autoload :SolrDocument
     autoload :StructDiv
     autoload :Structure
@@ -116,6 +117,14 @@ module Ddr
     # Is repository locked?  Default is false.
     # A locked repository behaves as though each object in the repository is locked.
     mattr_accessor :repository_locked do
+      false
+    end
+
+    mattr_accessor :auto_assign_permanent_id do
+      false
+    end
+
+    mattr_accessor :auto_update_permanent_id do
       false
     end
 

--- a/lib/ddr/models/permanent_id.rb
+++ b/lib/ddr/models/permanent_id.rb
@@ -1,0 +1,263 @@
+require 'ezid-client'
+
+module Ddr::Models
+  class PermanentId
+
+    class Error < Ddr::Models::Error; end
+    class AssignmentFailed < Error; end
+    class RepoObjectNotPersisted < Error; end
+    class AlreadyAssigned < AssignmentFailed; end
+    class IdentifierNotAssigned < Error; end
+    class IdentifierNotFound < Error; end
+
+    PERMANENT_URL_BASE = "https://idn.duke.edu/".freeze
+    DEFAULT_STATUS     = Ezid::Status::RESERVED
+    DEFAULT_EXPORT     = "no".freeze
+    DEFAULT_PROFILE    = "dc".freeze
+    DEFAULT_TARGET     = "https://repository.duke.edu/id/%s"
+    FCREPO3_PID        = "fcrepo3.pid".freeze
+    DELETED            = "deleted".freeze
+    DEACCESSIONED      = "deaccessioned".freeze
+
+    class_attribute :identifier_class, :identifier_repo_id_field
+
+    self.identifier_class = Ezid::Identifier
+    self.identifier_class.defaults = {
+      profile: DEFAULT_PROFILE,
+      export:  DEFAULT_EXPORT,
+      status:  DEFAULT_STATUS,
+    }
+
+    self.identifier_repo_id_field = FCREPO3_PID
+
+    # ActiveSupport::Notifications event handler
+    def self.call(*args)
+      event = ActiveSupport::Notifications::Event.new(*args)
+      repo_id, identifier_id, reason = event.payload.values_at(:pid, :permanent_id, :reason)
+      case event.name
+      when /workflow/
+        update!(repo_id) if auto_update?
+      when /^deaccession/
+        if auto_update? && identifier_id
+          deaccession!(repo_id, identifier_id, reason)
+        end
+      when /^destroy/
+        if auto_update? && identifier_id
+          delete!(repo_id, identifier_id, reason)
+        end
+      end
+    end
+
+    def self.auto_update?
+      Ddr::Models.auto_update_permanent_id
+    end
+
+    def self.deaccession!(repo_object_or_id, identifier_or_id, reason = nil)
+      new(repo_object_or_id, identifier_or_id).deaccession!(reason)
+    end
+
+    def self.delete!(repo_object_or_id, identifier_or_id, reason = nil)
+      new(repo_object_or_id, identifier_or_id).delete!(reason)
+    end
+
+    def self.update!(repo_object_or_id)
+      perm_id = new(repo_object_or_id)
+      perm_id.update! if perm_id.assigned?
+    end
+
+    def self.assign!(repo_object_or_id, identifier_or_id = nil)
+      new(repo_object_or_id, identifier_or_id).assign!
+    end
+
+    def self.assigned(repo_object_or_id)
+      perm_id = new(repo_object_or_id)
+      perm_id.assigned? ? perm_id : nil
+    end
+
+    def initialize(repo_object_or_id, identifier_or_id = nil)
+      case repo_object_or_id
+      when ActiveFedora::Base
+        raise RepoObjectNotPersisted, "Repository object must be persisted." if repo_object_or_id.new_record?
+        @repo_object = repo_object_or_id
+      when String, nil
+        @repo_id = repo_object_or_id
+      else
+        raise TypeError, "#{repo_object_or_id.class} is not expected as the first argument."
+      end
+
+      case identifier_or_id
+      when identifier_class
+        @identifier = identifier_or_id
+      when String, nil
+        @identifier_id = identifier_or_id
+      else
+        raise TypeError, "#{identifier_or_id.class} is not expected as the second argument."
+      end
+    end
+
+    def repo_object
+      @repo_object ||= ActiveFedora::Base.find(repo_id)
+    end
+
+    def repo_id
+      @repo_id ||= @repo_object && @repo_object.id
+    end
+
+    def assign!(id = nil)
+      ActiveSupport::Notifications.instrument("assign.permanent_id", pid: repo_object.id) do |payload|
+        assign(id)
+        software = [ "ddr-models #{Ddr::Models::VERSION}", Ezid::Client.version ].join("; ")
+        detail = <<-EOS
+Permanent ID:  #{repo_object.permanent_id}
+Permanent URL: #{repo_object.permanent_url}
+
+EZID Metadata:
+#{identifier.metadata}
+      EOS
+        payload.merge!(summary: "Permanent ID assignment",
+                       detail: detail,
+                       software: software,
+                       permanent_id: identifier.id)
+      end
+    end
+
+    def assigned?
+      repo_object.permanent_id
+    end
+
+    def update!
+      ActiveSupport::Notifications.instrument("update.permanent_id", pid: repo_object.id) do |payload|
+        update
+        payload.merge!(permanent_id: identifier.id)
+      end
+    end
+
+    def deaccession!(reason = nil)
+      delete_or_make_unavailable(reason || DEACCESSIONED)
+    end
+
+    def delete!(reason = nil)
+      delete_or_make_unavailable(reason || DELETED)
+    end
+
+    def identifier
+      if @identifier.nil?
+        if identifier_id
+          @identifier = find_identifier(identifier_id)
+        elsif assigned?
+          @identifier = find_identifier(repo_object.permanent_id)
+        end
+      end
+      @identifier
+    end
+
+    def identifier_id
+      @identifier_id ||= @identifier && @identifier.id
+    end
+
+    def set_permanent_url
+      repo_object.permanent_url = PERMANENT_URL_BASE + identifier.id
+    end
+
+    def set_metadata!
+      set_metadata
+      save
+      self
+    end
+
+    def set_metadata
+      set_target
+      set_status
+      set_identifier_repo_id
+    end
+
+    def set_target
+      self.target = DEFAULT_TARGET % id
+    end
+
+    def set_identifier_repo_id
+      self.identifier_repo_id = repo_object.id
+    end
+
+    def identifier_repo_id=(val)
+      if identifier_repo_id
+        raise Error, "Identifier repository id already set to \"#{identifier_repo_id}\"; cannot change."
+      end
+      self[identifier_repo_id_field] = val
+    end
+
+    def identifier_repo_id
+      self[identifier_repo_id_field]
+    end
+
+    def set_status!
+      save if set_status
+    end
+
+    def set_status
+      if repo_object.published? && !public?
+        public!
+      elsif repo_object.unpublished? && public?
+        unavailable!("not published")
+      end
+    end
+
+    protected
+
+    def method_missing(name, *args, &block)
+      identifier.send(name, *args, &block)
+    end
+
+    private
+
+    def find_identifier(ark)
+      identifier_class.find(ark)
+    rescue Ezid::IdentifierNotFoundError => e
+      raise IdentifierNotFound, e.message
+    end
+
+    def mint_identifier(*args)
+      identifier_class.mint(*args)
+    end
+
+    def update
+      if !assigned?
+        raise IdentifierNotAssigned,
+              "Cannot update identifier for repository object \"#{repo_object.id}\"; not assigned."
+      end
+      set_status!
+    end
+
+    def assign(id = nil)
+      if assigned?
+        raise AlreadyAssigned,
+              "Repository object \"#{repo_object.id}\" has already been assigned permanent id \"#{repo_object.permanent_id}\"."
+      end
+      @identifier = case id
+                    when identifier_class
+                      id
+                    when String
+                      find_identifier(id)
+                    when nil
+                      mint_identifier
+                    end
+      repo_object.reload
+      repo_object.permanent_id = identifier.id
+      repo_object.permanent_url = PERMANENT_URL_BASE + identifier.id
+      repo_object.save(validate: false)
+      set_metadata!
+    end
+
+    def delete_or_make_unavailable(reason)
+      if repo_id && identifier_repo_id && ( identifier_repo_id != repo_id )
+        raise Error, "Identifier \"#{identifier_id}\" is assigned to a different repository object \"#{repo_id}\"."
+      end
+      if reserved?
+        delete
+      else
+        unavailable!(reason) && save
+      end
+    end
+
+  end
+end

--- a/spec/models/permanent_id_spec.rb
+++ b/spec/models/permanent_id_spec.rb
@@ -1,0 +1,440 @@
+module Ddr::Models
+  RSpec.describe PermanentId do
+
+    describe "auto assigment" do
+      let(:obj) { FactoryGirl.create(:item) }
+      describe "when enabled" do
+        let!(:id) { described_class.identifier_class.new("foo") }
+        before do
+          allow(id).to receive(:save) { nil }
+          allow(described_class.identifier_class).to receive(:mint) { id }
+          allow(described_class.identifier_class).to receive(:find).with("foo") { id }
+          allow(Ddr::Models).to receive(:auto_assign_permanent_id) { true }
+        end
+        after do
+          obj.permanent_id = nil
+          obj.save!
+        end
+        it "assigns a permanent id to the object" do
+          obj.reload
+          expect(obj.permanent_id).to eq("foo")
+          expect(obj.permanent_url).to eq("https://idn.duke.edu/foo")
+        end
+      end
+      describe "when disabled" do
+        before do
+          allow(Ddr::Models).to receive(:auto_assign_permanent_id) { false }
+        end
+        it "does not assign a permanent id to the object" do
+          expect(obj.reload.permanent_id).to be_nil
+        end
+      end
+    end
+
+    describe "assignment" do
+      let(:obj) { FactoryGirl.create(:item) }
+      let!(:id) { described_class.identifier_class.new("foo") }
+      before do
+        allow(id).to receive(:save) { nil }
+        allow(described_class.identifier_class).to receive(:mint) { id }
+        allow(described_class.identifier_class).to receive(:find).with("foo") { id }
+      end
+      after do
+        obj.permanent_id = nil
+        obj.save!
+      end
+      it "creates an update event" do
+        expect { described_class.assign!(obj) }.to change(Ddr::Events::UpdateEvent, :count).to(1)
+      end
+    end
+
+    describe "auto updating" do
+      let(:obj) { Item.create(pid: "test:1") }
+      let!(:id) { described_class.identifier_class.new("foo") }
+      before do
+        allow(described_class.identifier_class).to receive(:find).with("foo") { id }
+      end
+      describe "when enabled" do
+        before do
+          allow(Ddr::Models).to receive(:auto_update_permanent_id) { true }
+        end
+        describe "when the object workflow state changes" do
+          describe "and the object has a permanent id" do
+            before do
+              allow(id).to receive(:save) { nil }
+              obj.permanent_id = "foo"
+            end
+            after do
+              obj.permanent_id = nil
+              obj.save!
+            end
+            it "updates the permanent id" do
+              expect { obj.publish! }.to change(id, :status).to("public")
+            end
+          end
+          describe "and the object does not have a permanent id" do
+            it "does not update the permanent id" do
+              expect { obj.publish! }.not_to change(id, :status)
+            end
+          end
+        end
+        describe "when the object workflow state does not change" do
+          it "does not update the permanent id" do
+            expect { obj.save! }.not_to change(id, :status)
+          end
+        end
+      end
+      describe "when disabled" do
+        before do
+          allow(Ddr::Models).to receive(:auto_update_permanent_id) { false }
+        end
+        describe "when the object workflow state changes" do
+          describe "and the object has a permanent id" do
+            before do
+              allow(id).to receive(:save) { nil }
+              obj.permanent_id = "foo"
+            end
+            after do
+              obj.permanent_id = nil
+              obj.save!
+            end
+            it "does not update the permanent id" do
+              expect { obj.publish! }.not_to change(id, :status)
+            end
+          end
+          describe "and the object does not have a permanent id" do
+            it "does not update the permanent id" do
+              expect { obj.publish! }.not_to change(id, :status)
+            end
+          end
+        end
+      end
+    end
+
+    describe "auto deleting / marking unavailable" do
+      describe "when enabled" do
+        before do
+          allow(Ddr::Models).to receive(:auto_update_permanent_id) { true }
+        end
+        describe "when an object has a permanent id" do
+          let(:obj) { Item.create(pid: "test:1", permanent_id: "foo") }
+          let!(:id) { described_class.identifier_class.new("foo") }
+          before do
+            allow(id).to receive(:save) { nil }
+            allow(described_class.identifier_class).to receive(:find).with("foo") { id }
+          end
+          describe "and it's deacessioned" do
+            specify {
+              expect(described_class).to receive(:deaccession!).with("test:1", "foo", nil) { nil }
+              obj.deaccession
+            }
+          end
+          describe "and it's deleted" do
+            specify {
+              expect(described_class).not_to receive(:delete!)
+              expect(described_class).not_to receive(:deaccession!)
+              obj.send(:delete)
+            }
+          end
+          describe "and it's destroyed" do
+            specify {
+              expect(described_class).to receive(:delete!).with("test:1", "foo", nil) { nil }
+              obj.destroy
+            }
+          end
+        end
+        describe "when an object does not have a permanent id" do
+          let(:obj) { FactoryGirl.create(:item) }
+          describe "and it's deacessioned" do
+            specify {
+              expect(described_class).not_to receive(:deaccession!)
+              obj.deaccession
+            }
+          end
+          describe "and it's deleted" do
+            specify {
+              expect(described_class).not_to receive(:deaccession!)
+              expect(described_class).not_to receive(:delete!)
+              obj.send(:delete)
+            }
+          end
+          describe "and it's destroyed" do
+            specify {
+              expect(described_class).not_to receive(:delete!)
+              obj.destroy
+            }
+          end
+        end
+      end
+      describe "when disabled" do
+        before do
+          allow(Ddr::Models).to receive(:auto_update_permanent_id) { false }
+        end
+        describe "when an object has a permanent id" do
+          let(:obj) { Item.create(pid: "test:1", permanent_id: "foo") }
+          let!(:id) { described_class.identifier_class.new("foo") }
+          before do
+            allow(id).to receive(:save) { nil }
+            allow(described_class.identifier_class).to receive(:find).with("foo") { id }
+          end
+          describe "and it's deacessioned" do
+            specify {
+              expect(described_class).not_to receive(:deaccession!)
+              obj.deaccession
+            }
+          end
+          describe "and it's destroyed" do
+            specify {
+              expect(described_class).not_to receive(:delete!)
+              obj.destroy
+            }
+          end
+        end
+      end
+    end
+
+    describe "constructor" do
+      describe "when the object is new" do
+        let(:obj) { FactoryGirl.build(:item) }
+        it "raises an error" do
+          expect { described_class.new(obj) }.to raise_error(PermanentId::RepoObjectNotPersisted)
+        end
+      end
+      describe "when passed a repo object id" do
+        let(:obj) { FactoryGirl.create(:item) }
+        subject { described_class.new(obj.id) }
+        its(:repo_id) { is_expected.to eq(obj.id) }
+      end
+    end
+
+    describe "instance methods" do
+      let(:obj) { FactoryGirl.create(:item) }
+      subject { described_class.new(obj) }
+
+      describe "#assign!" do
+        describe "when the object already has a permanent identifier" do
+          before { obj.permanent_id = "foo" }
+          it "raises an error" do
+            expect { subject.assign! }.to raise_error(PermanentId::AlreadyAssigned)
+            expect { subject.assign!("bar") }.to raise_error(PermanentId::AlreadyAssigned)
+          end
+        end
+        describe "when the object does not have a permanent identifier" do
+          let(:obj) { FactoryGirl.create(:item) }
+          let!(:id) { described_class.identifier_class.new("foo") }
+          before do
+            allow(described_class.identifier_class).to receive(:find).with("foo") { id }
+            allow(id).to receive(:save) { nil }
+            allow(obj).to receive(:save) { true }
+          end
+          describe "when passed an ARK" do
+            before do
+              subject.assign!("foo")
+            end
+            it "assigns the ARK" do
+              expect(obj.permanent_id).to eq("foo")
+            end
+            it "sets the target on the identifier" do
+              expect(id.target).to eq("https://repository.duke.edu/id/foo")
+            end
+            it "sets the status on the identifier" do
+              expect(id.status).to eq("reserved")
+            end
+            it "sets the repository id on the identifier" do
+              expect(id["fcrepo3.pid"]).to eq(obj.id)
+            end
+          end
+          describe "when not passed an ARK" do
+            before do
+              subject.assign!("foo")
+              allow(described_class.identifier_class).to receive(:mint) { id }
+            end
+            it "mints and assigns an ARK" do
+              expect(obj.permanent_id).to eq("foo")
+            end
+            it "sets the target on the identifier" do
+              expect(id.target).to eq("https://repository.duke.edu/id/foo")
+            end
+            it "sets the status on the identifier" do
+              expect(id.status).to eq("reserved")
+            end
+            it "sets the repository id on the identifier" do
+              expect(id["fcrepo3.pid"]).to eq(obj.id)
+            end
+          end
+        end
+      end
+
+      describe "#update!" do
+        describe "when the object has not been assigned a permanent id" do
+          it "raises an error" do
+            expect { subject.update! }.to raise_error(PermanentId::IdentifierNotAssigned)
+          end
+        end
+        describe "when the object has been assigned a permanent id" do
+          let!(:id) { described_class.identifier_class.new("foo") }
+          before do
+            allow(described_class.identifier_class).to receive(:find).with("foo") { id }
+            obj.permanent_id = "foo"
+          end
+          it "sets the status on the permanent id" do
+            expect(subject).to receive(:set_status!) { nil }
+            subject.update!
+          end
+        end
+      end
+
+      describe "#deaccession!" do
+        let!(:id) { described_class.identifier_class.new("foo") }
+        subject { described_class.new("test:1", "foo") }
+        before do
+          allow(described_class.identifier_class).to receive(:find).with("foo") { id }
+          allow(id).to receive(:save) { nil }
+        end
+        specify {
+          expect(id).to receive(:delete)
+          subject.deaccession!
+        }
+        describe " when the identifier is not reserved" do
+          before { id.public! }
+          specify {
+            expect { subject.deaccession! }.to change(id, :status).to("unavailable | deaccessioned")
+          }
+        end
+        describe "when the identifier is associated with another repo id" do
+          before { subject.identifier_repo_id = "test:2" }
+          specify {
+            expect { subject.deaccession! }.to raise_error(PermanentId::Error)
+          }
+        end
+      end
+
+      describe "#delete!" do
+        let!(:id) { described_class.identifier_class.new("foo") }
+        subject { described_class.new("test:1", "foo") }
+        before do
+          allow(described_class.identifier_class).to receive(:find).with("foo") { id }
+        end
+        specify {
+          expect(id).to receive(:delete)
+          subject.delete!
+        }
+        describe " when the identifier is not reserved" do
+          before do
+            allow(id).to receive(:save) { nil }
+            id.public!
+          end
+          specify {
+            expect { subject.delete! }.to change(id, :status).to("unavailable | deleted")
+          }
+        end
+        describe "when the identifier is associated with another repo id" do
+          before { subject.identifier_repo_id = "test:2" }
+          specify {
+            expect { subject.delete! }.to raise_error(PermanentId::Error)
+          }
+        end
+      end
+
+      describe "identifier metadata" do
+        let(:obj) { Item.create(pid: "test:1") }
+        let!(:id) { described_class.identifier_class.new("foo") }
+        subject { described_class.new(obj) }
+        before do
+          allow(subject).to receive(:identifier) { id }
+        end
+        describe "#identifier_repo_id" do
+          before do
+            id["fcrepo3.pid"] = "test:1"
+          end
+          its(:identifier_repo_id) { is_expected.to eq("test:1") }
+        end
+        describe "#identifier_repo_id=" do
+          specify {
+            subject.identifier_repo_id = "test:1"
+            expect(id["fcrepo3.pid"]).to eq("test:1")
+          }
+          describe "when a value was previously assigned" do
+            before { subject.identifier_repo_id = "test:1" }
+            specify {
+              expect { subject.identifier_repo_id = "test:2" }.to raise_error(PermanentId::Error)
+            }
+          end
+        end
+        describe "#set_identifier_repo_id" do
+          specify {
+            subject.set_identifier_repo_id
+            expect(subject.identifier_repo_id).to eq("test:1")
+          }
+        end
+        describe "#set_target" do
+          specify {
+            subject.set_target
+            expect(subject.target).to eq("https://repository.duke.edu/id/foo")
+          }
+        end
+        describe "#set_status" do
+          describe "when object is published" do
+            before { obj.workflow_state = "published" }
+            describe "and identifier is public" do
+              before { subject.public! }
+              it "does not change" do
+                expect { subject.set_status }.not_to change(subject, :status)
+              end
+            end
+            describe "and identifier is reserved" do
+              it "changes to public" do
+                expect { subject.set_status }.to change(subject, :status).to("public")
+              end
+            end
+            describe "and identifier is unavailable" do
+              before { subject.unavailable! }
+              it "changes to public" do
+                expect { subject.set_status }.to change(subject, :status).to("public")
+              end
+            end
+          end
+          describe "when object is unpublished" do
+            before { obj.workflow_state = "unpublished" }
+            describe "and identifier is public" do
+              before { subject.public! }
+              it "changes to unavailable" do
+                expect { subject.set_status }.to change(subject, :status).to("unavailable | not published")
+              end
+            end
+            describe "and identifier is reserved" do
+              it "does not change" do
+                expect { subject.set_status }.not_to change(subject, :status)
+              end
+            end
+            describe "and identifier is unavailable" do
+              before { subject.unavailable! }
+              it "does not change" do
+                expect { subject.set_status }.not_to change(subject, :status)
+              end
+            end
+          end
+          describe "when object has no workflow state" do
+            describe "and identifier is public" do
+              before { subject.public! }
+              it "does not change" do
+                expect { subject.set_status }.not_to change(subject, :status)
+              end
+            end
+            describe "and identifier is reserved" do
+              it "does not change" do
+                expect { subject.set_status }.not_to change(subject, :status)
+              end
+            end
+            describe "and identifier is unavailable" do
+              before { subject.unavailable! }
+              it "does not change" do
+                expect { subject.set_status }.not_to change(subject, :status)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Auto-assignment of permanent ID now happens synchronously in the
after_create callback.