### PR TITLE
Reloads collection before setting admin_policy to self.

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -14,7 +14,7 @@ class Collection < Ddr::Models::Base
   alias_method :items, :children
   alias_method :item_ids, :child_ids
 
-  after_create :set_admin_policy
+  after_create :set_admin_policy, unless: :admin_policy
 
   validates_presence_of :title
 
@@ -56,8 +56,9 @@ class Collection < Ddr::Models::Base
   private
 
   def set_admin_policy
+    reload
     self.admin_policy = self
-    self.save
+    save!
   end
 
 end

--- a/lib/ddr/models/permanent_id.rb
+++ b/lib/ddr/models/permanent_id.rb
@@ -244,7 +244,7 @@ EZID Metadata:
       repo_object.reload
       repo_object.permanent_id = identifier.id
       repo_object.permanent_url = PERMANENT_URL_BASE + identifier.id
-      repo_object.save(validate: false)
+      repo_object.save!
       set_metadata!
     end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Collection, type: :model do
 
+  subject { described_class.new(title: ["Test Collection"]) }
+
   it_behaves_like "a DDR model"
   it_behaves_like "it has an association", :has_many, :children, :is_member_of_collection, "Item"
   it_behaves_like "it has an association", :has_many, :targets, :is_external_target_for, "Target"
@@ -54,6 +56,9 @@ RSpec.describe Collection, type: :model do
   end
 
   describe "validation" do
+    before do
+      subject.title = nil
+    end
     it "requires a title" do
       expect(subject).to_not be_valid
       expect(subject.errors.messages).to have_key(:title)

--- a/spec/support/shared_examples_for_describables.rb
+++ b/spec/support/shared_examples_for_describables.rb
@@ -1,62 +1,62 @@
 RSpec.shared_examples "a describable object" do
-  let(:object) { described_class.new }
+
   context "having an identifier" do
     before do
-      object.identifier = ["id001"]
-      object.save(validate: false)
+      subject.identifier = ["id001"]
+      subject.save!
     end
-    it "should be findable by identifier" do
-      expect(described_class.find_by_identifier('id001')).to include object
+    it "is findable by identifier" do
+      expect(described_class.find_by_identifier('id001')).to include subject
     end
   end
   describe "#desc_metadata_terms" do
-    it "should have a default value" do
-      expect(object.desc_metadata_terms).to eq Ddr::Datastreams::DescriptiveMetadataDatastream.term_names
+    it "has a default value" do
+      expect(subject.desc_metadata_terms).to eq Ddr::Datastreams::DescriptiveMetadataDatastream.term_names
     end
     describe "arguments" do
       it "with fixed results" do
-        expect(object.desc_metadata_terms(:dcterms)).to eq(Ddr::Vocab::Vocabulary.term_names(RDF::DC11) + (Ddr::Vocab::Vocabulary.term_names(RDF::DC) - Ddr::Vocab::Vocabulary.term_names(RDF::DC11)))
-        expect(object.desc_metadata_terms(:dcterms)).to match_array Ddr::Vocab::Vocabulary.term_names(RDF::DC)
-        expect(object.desc_metadata_terms(:duke)).to eq Ddr::Vocab::Vocabulary.term_names(Ddr::Vocab::DukeTerms)
-        expect(object.desc_metadata_terms(:dcterms_elements11)).to eq Ddr::Vocab::Vocabulary.term_names(RDF::DC11)
-        expect(object.desc_metadata_terms(:defined_attributes)).to match_array Ddr::Vocab::Vocabulary.term_names(RDF::DC11)
+        expect(subject.desc_metadata_terms(:dcterms)).to eq(Ddr::Vocab::Vocabulary.term_names(RDF::DC11) + (Ddr::Vocab::Vocabulary.term_names(RDF::DC) - Ddr::Vocab::Vocabulary.term_names(RDF::DC11)))
+        expect(subject.desc_metadata_terms(:dcterms)).to match_array Ddr::Vocab::Vocabulary.term_names(RDF::DC)
+        expect(subject.desc_metadata_terms(:duke)).to eq Ddr::Vocab::Vocabulary.term_names(Ddr::Vocab::DukeTerms)
+        expect(subject.desc_metadata_terms(:dcterms_elements11)).to eq Ddr::Vocab::Vocabulary.term_names(RDF::DC11)
+        expect(subject.desc_metadata_terms(:defined_attributes)).to match_array Ddr::Vocab::Vocabulary.term_names(RDF::DC11)
       end
       context "with variable results" do
         before do
-          object.descMetadata.title = ["Object Title"]
-          object.descMetadata.creator = ["Duke University Libraries"]
-          object.descMetadata.identifier = ["id001"]
-          object.save
+          subject.descMetadata.title = ["Object Title"]
+          subject.descMetadata.creator = ["Duke University Libraries"]
+          subject.descMetadata.identifier = ["id001"]
+          subject.save!
         end
-        it "should accept an :empty argument" do
-          expect(object.desc_metadata_terms(:empty)).to eq(object.desc_metadata_terms - [:title, :creator, :identifier])
+        it "accepts an :empty argument" do
+          expect(subject.desc_metadata_terms(:empty)).to eq(subject.desc_metadata_terms - [:title, :creator, :identifier])
         end
-        it "should accept a :present argument" do
-          expect(object.desc_metadata_terms(:present)).to match_array [:title, :creator, :identifier]
+        it "accepts a :present argument" do
+          expect(subject.desc_metadata_terms(:present)).to match_array [:title, :creator, :identifier]
         end
       end
     end
   end
   describe "#set_desc_metadata" do
-    let(:term_values_hash) { object.desc_metadata_terms.each_with_object({}) {|t, memo| memo[t] = ["Value"]} }
-    it "should set the descMetadata terms to the values of the matching keys in the hash" do
-      object.desc_metadata_terms.each do |t|
-        expect(object).to receive(:set_desc_metadata_values).with(t, ["Value"])
+    let(:term_values_hash) { subject.desc_metadata_terms.each_with_object({}) {|t, memo| memo[t] = ["Value"]} }
+    it "sets the descMetadata terms to the values of the matching keys in the hash" do
+      subject.desc_metadata_terms.each do |t|
+        expect(subject).to receive(:set_desc_metadata_values).with(t, ["Value"])
       end
-      object.set_desc_metadata(term_values_hash)
+      subject.set_desc_metadata(term_values_hash)
     end
   end
   describe "#set_desc_metadata_values" do
     context "when values == nil" do
-      it "should set the term to an empty value" do
-        object.set_desc_metadata_values(:title, nil)
-        expect(object.descMetadata.title).to be_empty
+      it "sets the term to an empty value" do
+        subject.set_desc_metadata_values(:title, nil)
+        expect(subject.descMetadata.title).to be_empty
       end
     end
     context "when values is an array" do
-      it "should reject empty values from the array" do
-        object.set_desc_metadata_values(:title, ["Object Title", nil, "Alternative Title", ""])
-        expect(object.descMetadata.title).to eq ["Object Title", "Alternative Title"]
+      it "rejects empty values from the array" do
+        subject.set_desc_metadata_values(:title, ["Object Title", nil, "Alternative Title", ""])
+        expect(subject.descMetadata.title).to eq ["Object Title", "Alternative Title"]
       end
     end
   end


### PR DESCRIPTION
Removes bypass of validation in permanent ID assignment.