### PR TITLE
Removes legacy custom setting for external file stores.

### DIFF
--- a/lib/ddr/datastreams/external_file_datastream.rb
+++ b/lib/ddr/datastreams/external_file_datastream.rb
@@ -28,10 +28,6 @@ module Ddr::Datastreams
       self.dsLocation = Ddr::Utils.path_to_uri(path)
     end
 
-    def get_file_store
-      file_store || Ddr::Models.external_file_store
-    end
-
     def generate_file_name
       SecureRandom.uuid
     end
@@ -39,7 +35,7 @@ module Ddr::Datastreams
     def generate_stored_path
       file_name = generate_file_name
       subpath = File.join([0, 2, 4, 6].map { |i| file_name[i, 2] })
-      File.join(get_file_store, subpath, file_name)
+      File.join(file_store, subpath, file_name)
     end
 
     def file_paths

--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -88,15 +88,6 @@ module Ddr
       autoload :StructMap
     end
 
-    # Base directory of default external file store
-    mattr_accessor :external_file_store
-
-    # Base directory of external file store for multires image derivatives
-    mattr_accessor :multires_image_external_file_store
-
-    # Regexp for building external file subpath from hex digest
-    mattr_accessor :external_file_subpath_regexp
-
     # Image server URL
     mattr_accessor :image_server_url
 

--- a/lib/ddr/models/engine.rb
+++ b/lib/ddr/models/engine.rb
@@ -48,11 +48,6 @@ module Ddr
                                                 [ :thumbnail ]
       end
 
-      initializer "ddr_models.external_files" do
-        Ddr::Models.external_file_store = ENV["EXTERNAL_FILE_STORE"]
-        Ddr::Datastreams::MultiresImageDatastream.file_store = ENV["MULTIRES_IMAGE_EXTERNAL_FILE_STORE"]
-      end
-
       initializer "ddr_models.image_server" do
         Ddr::Models.image_server_url = ENV["IMAGE_SERVER_URL"]
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,18 +108,14 @@ RSpec.configure do |config|
       config.update_derivatives = [ :multires_image, :thumbnail ]
     end
     Ddr::Models.configure do |config|
-      config.external_file_store = Dir.mktmpdir
-      config.multires_image_external_file_store = Dir.mktmpdir
       config.fits_home = Dir.mktmpdir
     end
+    Ddr::Datastreams::ExternalFileDatastream.file_store = Dir.mktmpdir
   end
 
   config.after(:suite) do
-    if Ddr::Models.external_file_store && Dir.exist?(Ddr::Models.external_file_store)
-      FileUtils.remove_entry_secure(Ddr::Models.external_file_store)
-    end
-    if Ddr::Models.multires_image_external_file_store && Dir.exist?(Ddr::Models.multires_image_external_file_store)
-      FileUtils.remove_entry_secure(Ddr::Models.multires_image_external_file_store)
+    if Ddr::Datastreams::ExternalFileDatastream.file_store
+      FileUtils.rm_rf Ddr::Datastreams::ExternalFileDatastream.file_store
     end
   end
 


### PR DESCRIPTION
Upgrade notes:
- In environment config, expicitly set EITHER
`Ddr::Datastreams::ExternalFileDatastream.file_store`
OR
set `.file_store` on each of the external datastreams:
`Ddr::Datastreams::ContentDatastream`, `Ddr::Datastreams::MultiresImageDatastream`,
and `Ddr::Datastreams::IntermediateFileDatastream`.
- Remove `EXTERNAL_FILE_STORE` and `MULTIRES_IMAGE_EXTERNAL_FILE_STORE` local
environment settings.