### PR TITLE
Hotfix v2.6.2.

### DIFF
--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "devise", "~> 3.4"
   s.add_dependency "omniauth-shibboleth", "~> 1.2.0"
   s.add_dependency "grouper-rest-client"
-  s.add_dependency "ezid-client", "~> 1.4.2"
+  s.add_dependency "ezid-client", "~> 1.6"
   s.add_dependency "resque", "~> 1.25"
   s.add_dependency "rdf-vocab", "~> 0.8"
   s.add_dependency "net-ldap", "~> 0.11"

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.6.1"
+    VERSION = "2.6.2"
   end
 end


### PR DESCRIPTION
Loosens ezid-client dependency to 1.x (1.6+).