### PR TITLE
Hotfix v2.7.2

### DIFF
--- a/lib/ddr/derivatives/update_derivatives.rb
+++ b/lib/ddr/derivatives/update_derivatives.rb
@@ -3,15 +3,17 @@ module Ddr::Derivatives
 
     def self.call(*args)
       event = ActiveSupport::Notifications::Event.new(*args)
+      payload = event.payload
+      return false if payload[:skip_update_derivatives]
       if event.name == "delete.repo_file" &&
-         !file_ids.include?(event.payload[:file_id])
+         !file_ids.include?(payload[:file_id])
         return false
       end
       if event.name =~ /\.repo_object\z/ &&
-         (file_ids & event.payload[:datastreams_changed]).empty?
+         (file_ids & payload[:datastreams_changed]).empty?
         return false
       end
-      obj = ActiveFedora::Base.find(event.payload[:pid])
+      obj = ActiveFedora::Base.find(payload[:pid])
       obj.derivatives.update_derivatives(:later)
     end
 

--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -148,7 +148,8 @@ module Ddr
       def notify_update
         event_params = default_notification_payload.merge(
           attributes_changed: changes,
-          datastreams_changed: datastreams_changed.keys
+          datastreams_changed: datastreams_changed.keys,
+          skip_update_derivatives: cache.fetch(:skip_update_derivatives, false)
         )
         ActiveSupport::Notifications.instrument(UPDATE, event_params) do |payload|
           yield

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.7.1"
+    VERSION = "2.7.2"
   end
 end

--- a/spec/support/shared_examples_for_has_content.rb
+++ b/spec/support/shared_examples_for_has_content.rb
@@ -78,6 +78,13 @@ RSpec.shared_examples "an object that can have content" do
           expect_any_instance_of(Ddr::Managers::DerivativesManager).to receive(:update_derivatives)
           subject.upload! file
         end
+        context "and it is saved with :skip_update_derivatives=>true" do
+          it "does not generate derivatives" do
+            expect_any_instance_of(Ddr::Managers::DerivativesManager).not_to receive(:update_derivatives)
+            subject.upload file
+            subject.save(skip_update_derivatives: true)
+          end
+        end
         context "and the file has not previously been characterized" do
           it "does not try to delete the existing characterization data" do
             expect(subject.fits).not_to receive(:delete)


### PR DESCRIPTION
Adds support for `skip_update_derivatives: true` option to `save`
to bypass derivative generation on object update.