### PR TITLE
Hotfix v2.7.4

### DIFF
--- a/lib/ddr/models/file_management.rb
+++ b/lib/ddr/models/file_management.rb
@@ -19,10 +19,10 @@ module Ddr::Models
     # @param external [Boolean] Add file to external datastream.
     #   Not required for external datastream classes
     #   or datastream instances having controlGroup 'E'.
-    def add_file(file, dsid, mime_type: nil, external: false)
-      mime_type       ||= Ddr::Utils.mime_type_for(file)
-      source_path       = Ddr::Utils.file_path(file)
-      original_filename = Ddr::Utils.file_name(file)
+    def add_file(file, dsid, mime_type: nil, external: false, original_filename: nil)
+      mime_type         ||= Ddr::Utils.mime_type_for(file)
+      source_path         = Ddr::Utils.file_path(file)
+      original_filename ||= Ddr::Utils.file_name(file)
       file_to_add = FileToAdd.new(dsid, source_path, original_filename)
       cache.with(file_to_add: file_to_add) do
         run_callbacks(:add_file) do

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.7.3"
+    VERSION = "2.7.4"
   end
 end

--- a/spec/models/file_management_spec.rb
+++ b/spec/models/file_management_spec.rb
@@ -1,17 +1,17 @@
 RSpec.shared_examples "a repository external file" do
-  it "should be owned by the effective user" do
+  it "is owned by the effective user" do
     expect(File.owned?(file_path)).to be true
   end
-  it "should be readable by the effective user" do
+  it "is readable by the effective user" do
     expect(File.readable?(file_path)).to be true
   end
-  it "should be writable by the effective user" do
+  it "is writable by the effective user" do
     expect(File.writable?(file_path)).to be true
   end
-  it "should not have the sticky bit set" do
+  it "does not have the sticky bit set" do
     expect(File.sticky?(file_path)).to be false
   end
-  it "should have 644 mode" do
+  it "has 644 mode" do
     expect("%o" % File.world_readable?(file_path)).to eq "644"
   end
 end
@@ -24,51 +24,61 @@ module Ddr::Models
     let(:xml_file)   { fixture_file_upload("fits/image.xml", "text/xml") }
 
     describe "#add_file" do
-      it "should run a virus scan on the file" do
+      it "runs a virus scan on the file" do
         expect(object).to receive(:virus_scan)
         object.add_file image_file, "content"
       end
-      it "should call add_file_datastream by default" do
+      it "calls add_file_datastream by default" do
         expect(object).to receive(:add_file_datastream)
         object.add_file image_file, "random_ds_1"
       end
-      it "should call add_file_datastream when dsid spec is managed" do
+      it "calls add_file_datastream when dsid spec is managed" do
         expect(object).to receive(:add_file_datastream)
         object.add_file xml_file, "fits"
       end
-      it "should call add_external_file when dsid spec is external" do
+      it "calls add_external_file when dsid spec is external" do
         expect(object).to receive(:add_external_file)
                            .with(image_file, "content", mime_type: "image/tiff")
         object.add_file image_file, "content"
       end
-      it "should call add_external_file when :external => true option passed" do
+      it "calls add_external_file when :external => true option passed" do
         expect(object).to receive(:add_external_file)
                            .with(image_file, "random_ds_2", mime_type: "image/tiff")
         object.add_file image_file, "random_ds_2", external: true
       end
-      it "sets original filename when dsid == 'content'" do
-        expect { object.add_file image_file, "content" }
-          .to change(object, :original_filename).to("imageA.tif")
-      end
-      it "does not set original filename when dsid != 'content'" do
-        expect { object.add_file xml_file, "fits" }
-          .not_to change(object, :original_filename)
+      context "original_filename" do
+        context "when dsid == 'content'" do
+          it "sets original_filename" do
+            expect { object.add_file image_file, "content" }
+              .to change(object, :original_filename).to("imageA.tif")
+            expect { object.add_file image_file, "content", original_filename: "foo.tif" }
+              .to change(object, :original_filename).to("foo.tif")
+          end
+        end
+        context "when dsid != 'content'" do
+          it "does not set original_filename" do
+            expect { object.add_file xml_file, "fits" }
+              .not_to change(object, :original_filename)
+            expect { object.add_file xml_file, "fits", original_filename: "foo" }
+              .not_to change(object, :original_filename)
+          end
+        end
       end
     end
 
     describe "#add_external_file" do
-      it "should call add_external_datastream if no spec for dsid" do
+      it "calls add_external_datastream if no spec for dsid" do
         expect(object).to receive(:add_external_datastream).with("random_ds_3").and_call_original
         object.add_external_file(image_file, "random_ds_3")
       end
-      it "should raise an error if datastream is not external" do
+      it "raises an exception if datastream is not external" do
         expect { object.add_external_file(xml_file, "fits") }.to raise_error(ArgumentError)
       end
-      it "should set the mimeType" do
+      it "sets the mimeType" do
         expect(object.content).to receive(:mimeType=).with("image/tiff")
         object.add_external_file(image_file, "content", mime_type: "image/tiff")
       end
-      it "should set dsLocation to URI for generated file path by default" do
+      it "sets dsLocation to URI for generated file path by default" do
         object.add_external_file(image_file, "content")
         expect(object.content.dsLocation).not_to eq URI.escape("file:#{image_file.path}")
         expect(object.content.dsLocation).not_to be_nil
@@ -83,7 +93,7 @@ module Ddr::Models
     end
 
     describe "#add_external_datastream" do
-      it "should return a new external datastream" do
+      it "returns a new external datastream" do
         ds = object.add_external_datastream("random_ds_27")
         expect(ds.controlGroup).to eq "E"
         expect(object.datastreams["random_ds_27"]).to eq ds
@@ -100,7 +110,7 @@ module Ddr::Models
         object.add_file(file2, "e_content_2", external: true)
         object.save
       end
-      it "should return a list of file paths for all versions of all external datastreams for the object" do
+      it "returns a list of file paths for all versions of all external datastreams for the object" do
         paths = object.external_datastream_file_paths
         expect(paths.size).to eq 2
         paths.each do |path|


### PR DESCRIPTION
Adds :original_filename option to FileManagement#add_file to
support overriding the default usage of the file path.