### PR TITLE
Hotfix v2.7.6

### DIFF
--- a/lib/ddr/datastreams/external_file_datastream.rb
+++ b/lib/ddr/datastreams/external_file_datastream.rb
@@ -16,7 +16,7 @@ module Ddr::Datastreams
     end
 
     def content
-      File.read(file_path)
+      external? ? File.read(file_path) : super
     end
 
     def file_size

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.7.5"
+    VERSION = "2.7.6"
   end
 end


### PR DESCRIPTION
Fixes Ddr::Datastreams::ExternalFileDatastream#content when
controlGroup is not E by reverting to superclass behavior.