### PR TITLE
Adds `Ddr::Models.preferred_media_types`.

### DIFF
--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -58,6 +58,7 @@ module Ddr
     autoload :HasStructMetadata
     autoload :HasThumbnail
     autoload :Indexing
+    autoload :MediaType
     autoload :NotFoundError, 'ddr/models/error'
     autoload :PermanentId
     autoload :SolrDocument
@@ -135,6 +136,21 @@ module Ddr
 
     mattr_accessor :default_mime_type do
       "application/octet-stream"
+    end
+
+    # Maps file extensions to preferred media types
+    mattr_accessor :preferred_media_types do
+      {
+        '.mp4'  => 'video/mp4',
+        '.flv'  => 'video/flv',
+        '.webm' => 'video/webm',
+        '.aac'  => 'audio/mp4',
+        '.m4a'  => 'audio/mp4',
+        '.f4a'  => 'audio/mp4',
+        '.mp3'  => 'audio/mpeg',
+        '.ogg'  => 'audio/ogg',
+        '.oga'  => 'audio/ogg',
+      }
     end
 
     # Yields an object with module configuration accessors

--- a/lib/ddr/models/file_management.rb
+++ b/lib/ddr/models/file_management.rb
@@ -20,7 +20,7 @@ module Ddr::Models
     #   Not required for external datastream classes
     #   or datastream instances having controlGroup 'E'.
     def add_file(file, dsid, mime_type: nil, external: false, original_filename: nil)
-      mime_type         ||= Ddr::Utils.mime_type_for(file)
+      mime_type         ||= MediaType.call(file) # XXX Should we use original_filename, if present?
       source_path         = Ddr::Utils.file_path(file)
       original_filename ||= Ddr::Utils.file_name(file)
       file_to_add = FileToAdd.new(dsid, source_path, original_filename)

--- a/lib/ddr/models/media_type.rb
+++ b/lib/ddr/models/media_type.rb
@@ -1,0 +1,22 @@
+module Ddr::Models
+  class MediaType
+
+    def self.call(file_or_path)
+      path = file_or_path.respond_to?(:path) ? file_or_path.path : file_or_path
+      # Use preferred media type, if available
+      media_type = Ddr::Models.preferred_media_types[File.extname(path)]
+      if !media_type
+        if file_or_path.respond_to?(:content_type)
+          # Rails ActionDispatch::Http::UploadedFile
+          media_type = file_or_path.content_type
+        else
+          # Fall back to first MIME type or default
+          mime_types = MIME::Types.of(path)
+          media_type = mime_types.empty? ? Ddr::Models.default_mime_type : mime_types.first.content_type
+        end
+      end
+      media_type
+    end
+
+  end
+end

--- a/lib/ddr/utils.rb
+++ b/lib/ddr/utils.rb
@@ -1,6 +1,7 @@
 require 'openssl'
 
 module Ddr::Utils
+  extend Deprecation
 
   def self.digest content, algorithm
     raise TypeError, "Algorithm must be a string: #{algorithm.inspect}" unless algorithm.is_a?(String)
@@ -14,10 +15,9 @@ module Ddr::Utils
   # file can be a File object or file path (String)
   # @return [String] the mime type or default
   def self.mime_type_for(file, file_name=nil)
-    return file.content_type if file.respond_to?(:content_type) # E.g., Rails uploaded file
-    path = file_name || file_path(file) rescue nil
-    mime_types = MIME::Types.of(path) rescue []                 # MIME::Types.of blows up on nil
-    mime_types.empty? ? Ddr::Models.default_mime_type : mime_types.first.content_type
+    Deprecation.warn(self, "`Ddr::Utils.mime_type_for` is deprecated and will be removed in ddr-models 3.0." \
+                           " Use `Ddr::Models::MediaType.call(file)` instead. (called from #{caller.first})")
+    Ddr::Models::MediaType.call(file_name || file)
   end
 
   def self.file_or_path?(file)

--- a/spec/models/media_type_spec.rb
+++ b/spec/models/media_type_spec.rb
@@ -1,0 +1,46 @@
+module Ddr::Models
+  RSpec.describe MediaType do
+
+    subject { described_class.call(file) }
+
+    describe "when a preferred media type is available" do
+      describe "with a file path" do
+        let(:file) { 'foo.mp4' }
+        it { is_expected.to eq 'video/mp4' }
+      end
+      describe "with an object that responds to :path" do
+        let(:file) { double(path: 'foo.mp4') }
+        it { is_expected.to eq 'video/mp4' }
+      end
+    end
+    describe "when a preferred media type is not available" do
+      describe "and the file responds to :content_type" do
+        let(:file) { double(path: 'foo.jpg', content_type: 'foo/bar') }
+        it { is_expected.to eq 'foo/bar' }
+      end
+      describe "and the file does not respond to :content_type" do
+        describe "and MIME types are present" do
+          describe "with an object that responds to :path" do
+            let(:file) { double(path: 'foo.jpg') }
+            it { is_expected.to eq 'image/jpeg' }
+          end
+          describe "with a file path" do
+            let(:file) { 'foo.jpg' }
+            it { is_expected.to eq 'image/jpeg' }
+          end
+        end
+        describe "and MIME types are not present" do
+          describe "with an object that responds to :path" do
+            let(:file) { double(path: 'foo.bar') }
+            it { is_expected.to eq 'application/octet-stream' }
+          end
+          describe "with a file path" do
+            let(:file) { 'foo.bar' }
+            it { is_expected.to eq 'application/octet-stream' }
+          end
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
For mapping file extensions to preferred media types, especially
for streamable media (DDR-871).

`Ddr::Models::MediaType.call` replaces the now-deprecated method
`Ddr::Utils.mime_type_for`.