### PR TITLE
Adds new ActiveResource model `Ddr::Models::RightsStatement`.

### DIFF
--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -61,6 +61,7 @@ module Ddr
     autoload :MediaType
     autoload :NotFoundError, 'ddr/models/error'
     autoload :PermanentId
+    autoload :RightsStatement
     autoload :SolrDocument
     autoload :Streamable
     autoload :Structure

--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -36,6 +36,10 @@ module Ddr
       around_deaccession :notify_deaccession
       around_destroy :notify_delete
 
+      def rights_statement
+        RightsStatement.call(self) || EffectiveLicense.call(self)
+      end
+
       def deaccession
         run_callbacks :deaccession do
           delete

--- a/lib/ddr/models/has_admin_metadata.rb
+++ b/lib/ddr/models/has_admin_metadata.rb
@@ -1,6 +1,9 @@
 module Ddr::Models
   module HasAdminMetadata
     extend ActiveSupport::Concern
+    extend Deprecation
+
+    self.deprecation_horizon = 'ddr-models v3.0'
 
     included do
       has_metadata "adminMetadata",
@@ -69,10 +72,12 @@ module Ddr::Models
     def effective_license
       EffectiveLicense.call(self)
     end
+    deprecation_deprecate :effective_license
 
     def inherited_license
       InheritedLicense.call(self)
     end
+    deprecation_deprecate :inherited_license
 
     def finding_aid
       if ead_id

--- a/lib/ddr/models/rights_statement.rb
+++ b/lib/ddr/models/rights_statement.rb
@@ -1,18 +1,13 @@
 require "active_resource"
 
 module Ddr::Models
-  class License < ActiveResource::Base
+  class RightsStatement < ActiveResource::Base
 
     self.site = ENV["DDR_AUX_API_URL"]
-    self.element_name = "rights_statement"
-
-    attr_accessor :pid
 
     def self.call(obj)
-      if obj.license
-        license = new get(:find, url: obj.license)
-        license.pid = obj.pid
-        license
+      if obj.rights.present?
+        new get(:find, url: obj.rights.first)
       end
     rescue ActiveResource::ResourceNotFound => e
       raise Ddr::Models::NotFoundError, e

--- a/lib/ddr/models/solr_document.rb
+++ b/lib/ddr/models/solr_document.rb
@@ -3,6 +3,9 @@ require 'json'
 module Ddr::Models
   module SolrDocument
     extend ActiveSupport::Concern
+    extend Deprecation
+
+    self.deprecation_horizon = 'ddr-models v3.0'
 
     included do
       alias_method :pid, :id
@@ -179,6 +182,11 @@ module Ddr::Models
     def effective_license
       @effective_license ||= EffectiveLicense.call(self)
     end
+    deprecation_deprecate :effective_license
+
+    def rights_statement
+      @rights_statement ||= RightsStatement.call(self) || EffectiveLicense.call(self)
+    end
 
     def roles
       @roles ||= Ddr::Auth::Roles::DetachedRoleSet.from_json(access_role)
@@ -236,6 +244,11 @@ module Ddr::Models
       if streamable?
         Ddr::Utils.path_from_uri(datastreams[Ddr::Datastreams::STREAMABLE_MEDIA]["dsLocation"])
       end
+    end
+
+    # FIXME - Probably need a more general solution mapping object reader methods to index field names.
+    def rights
+      self["rights_tesim"]
     end
 
     private

--- a/spec/models/rights_statement_spec.rb
+++ b/spec/models/rights_statement_spec.rb
@@ -1,0 +1,55 @@
+module Ddr::Models
+  RSpec.describe RightsStatement, ddr_aux: true do
+
+    describe ".call" do
+      describe "when the object has a rights statement URL" do
+        let(:obj) { double(pid: "test:1", rights: ["http://example.com"]) }
+        describe "and the rights statement is found" do
+          before {
+            allow(described_class).to receive(:get).with(:find, url: "http://example.com") {
+              {"id"=>1, "url"=>"http://example.com", "title"=>"A Rights Statement"}
+            }
+          }
+          it "returns a Rights Statement instance" do
+            expect(described_class.call(obj)).to be_a(described_class)
+          end
+        end
+        describe "and the rights statement is not found" do
+          before {
+            allow(described_class).to receive(:get).with(:find, url: "http://example.com")
+                                       .and_raise(ActiveResource::ResourceNotFound, "404")
+          }
+          it "raises an exception" do
+            expect { described_class.call(obj) }.to raise_error(Ddr::Models::NotFoundError)
+          end
+        end
+      end
+
+      describe "when the object does not have a rights statement" do
+        let(:obj) { double(pid: "test:1", rights: []) }
+        it "returns nil" do
+          expect(described_class.call(obj)).to be_nil
+        end
+      end
+    end
+
+    describe ".keys" do
+      let(:entries) { [ described_class.new(id: 1, url: 'http://localhost/licenseA', title: 'License A'),
+                        described_class.new(id: 2, url: 'http://localhost/licenseB', title: 'License B') ] }
+      let(:response_collection) { ActiveResource::Collection.new }
+      before do
+        response_collection.elements = entries
+        allow(described_class).to receive(:all) { response_collection }
+      end
+      it "returns the defined urls" do
+        expect(described_class.keys).to match_array([ entries[0].url, entries[1].url ])
+      end
+    end
+
+    describe "instance methods" do
+      subject { described_class.new("id"=>1, "url"=>"http://example.com", "title"=>"A License") }
+      its(:to_s) { is_expected.to eq("A License") }
+    end
+
+  end
+end

--- a/spec/support/shared_examples_for_ddr_models.rb
+++ b/spec/support/shared_examples_for_ddr_models.rb
@@ -154,4 +154,46 @@ RSpec.shared_examples "a DDR model" do
       expect(subject).to have_thumbnail
     }
   end
+
+  describe "#rights_statement" do
+    let(:rights_statement) { Ddr::Models::RightsStatement.new(url: "http://example.com") }
+    let(:license) { Ddr::Models::License.new(url: "http://example.com") }
+    before do
+      allow(Ddr::Models::RightsStatement).to receive(:get).with(:find, url: "http://example.com") do
+        { url: "http://example.com" }
+      end
+    end
+    describe "when `rights` is present" do
+      before {
+        subject.rights = ["http://example.com"]
+      }
+      specify {
+        expect(Ddr::Models::EffectiveLicense).not_to receive(:call).with(subject)
+        expect(subject.rights_statement).to eq rights_statement
+      }
+    end
+    describe "when `rights` is not present" do
+      describe "and effective license is present" do
+        before do
+          allow(Ddr::Models::License).to receive(:get).with(:find, url: "http://example.com") do
+            { url: "http://example.com" }
+          end
+        end
+        specify {
+          subject.license = "http://example.com"
+          expect(Ddr::Models::RightsStatement).to receive(:call).with(subject).and_call_original
+          expect(Ddr::Models::EffectiveLicense).to receive(:call).with(subject).and_call_original
+          expect(subject.rights_statement).to eq license
+        }
+      end
+      describe "and `license` is not present" do
+        specify {
+          expect(Ddr::Models::RightsStatement).to receive(:call).with(subject).and_call_original
+          expect(Ddr::Models::EffectiveLicense).to receive(:call).with(subject).and_call_original
+          expect(subject.rights_statement).to be_nil
+        }
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
The new model supersedes `Ddr::Models::License`, which should
be considered deprecated.

Adds `#rights_statement` methods to `Ddr::Models::Base` and
`Ddr::Models::SolrDocument`. These methods supersede
`#effective_license`, which is deprecated and should no
longer be used.

As a transitional measure, `#rights_statement` may return
either a RightsStatement or License instance, depending on
the source of data used. Both models will have the same
attributes and reference the same set of remote data.

After production data has been migrated from dcterms:license
to dcterms:rights, the legacy license methods and models will be
removed.

Completes DDR-867.