### PR TITLE
Add attribute for original filepath to Component.  Addresses DDR-909.

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -37,4 +37,8 @@ class Item < Ddr::Models::Base
     children_having_extracted_text.docs.map(&:extracted_text).flatten
   end
 
+  def original_dirname
+    children.first.original_dirname if children.count == 1
+  end
+
 end

--- a/lib/ddr/datastreams/administrative_metadata_datastream.rb
+++ b/lib/ddr/datastreams/administrative_metadata_datastream.rb
@@ -15,6 +15,9 @@ module Ddr
         index.as :stored_sortable
       end
 
+      property :original_dirname,
+               predicate: Ddr::Vocab::Asset.hasOriginalDirname
+
       property :workflow_state,
                predicate: Ddr::Vocab::Asset.workflowState
 

--- a/lib/ddr/index/fields.rb
+++ b/lib/ddr/index/fields.rb
@@ -78,6 +78,7 @@ module Ddr::Index
     OBJECT_STATE                = Field.new :object_state, :stored_sortable
     OBJECT_CREATE_DATE          = Field.new :system_create, :stored_sortable, type: :date
     OBJECT_MODIFIED_DATE        = Field.new :system_modified, :stored_sortable, type: :date
+    ORIGINAL_DIRNAME            = Field.new :original_dirname, :stored_sortable, type: :string
     PERFORMER_FACET             = Field.new :performer_facet, :facetable
     PERMANENT_ID                = Field.new :permanent_id, :stored_sortable, type: :string
     PERMANENT_URL               = Field.new :permanent_url, :stored_sortable, type: :string

--- a/lib/ddr/models/has_content.rb
+++ b/lib/ddr/models/has_content.rb
@@ -25,7 +25,10 @@ module Ddr
           label: "FITS Output for content file",
           control_group: "M"
 
-        has_attributes :original_filename, datastream: "adminMetadata", multiple: false
+        has_attributes :original_filename,
+                       :original_dirname,
+                       datastream: "adminMetadata",
+                       multiple: false
 
         include FileManagement
 

--- a/lib/ddr/models/indexing.rb
+++ b/lib/ddr/models/indexing.rb
@@ -102,6 +102,7 @@ module Ddr::Models
         fields[MEDIA_TYPE] = content_type
         fields[MEDIA_MAJOR_TYPE] = content_major_type
         fields[MEDIA_SUB_TYPE] = content_sub_type
+        fields[ORIGINAL_DIRNAME] = original_dirname
         fields.merge! techmd.index_fields
       end
       if has_multires_image?

--- a/lib/ddr/models/solr_document.rb
+++ b/lib/ddr/models/solr_document.rb
@@ -248,6 +248,22 @@ module Ddr::Models
       self["rights_tesim"]
     end
 
+    def original_dirname
+      if self[Ddr::Index::Fields::ORIGINAL_DIRNAME]
+        self[Ddr::Index::Fields::ORIGINAL_DIRNAME]
+      elsif self[Ddr::Index::Fields::ACTIVE_FEDORA_MODEL] == 'Item'
+        if childrn = children
+          if childrn.count == 1
+            childrn.first.original_dirname
+          end
+        end
+      end
+    end
+
+    def children
+      children_query.docs rescue []
+    end
+
     private
 
     def targets_query
@@ -296,5 +312,17 @@ module Ddr::Models
       structure['default'] || structure.values.first
     end
 
+    def children_query
+      case self[Ddr::Index::Fields::ACTIVE_FEDORA_MODEL]
+        when 'Collection'
+          Ddr::Index::Query.build(self) do |parent|
+            is_member_of_collection parent.id
+          end
+        when 'Item'
+          Ddr::Index::Query.build(self) do |parent|
+            is_part_of parent.id
+          end
+      end
+    end
   end
 end

--- a/lib/ddr/vocab/asset.rb
+++ b/lib/ddr/vocab/asset.rb
@@ -43,5 +43,9 @@ module Ddr::Vocab
              label: "Affiliation",
              comment: "An organizational entity associated with the object content."
 
+    property "hasOriginalDirname",
+             label: "Original Dirname",
+             comment: "The dirname (directory path without the file name) of the object in the source filesystem."
+
   end
 end

--- a/spec/models/indexing_spec.rb
+++ b/spec/models/indexing_spec.rb
@@ -106,8 +106,10 @@ module Ddr::Models
     describe "content-bearing object indexing" do
       let(:obj) { FactoryGirl.create(:component) }
       let!(:create_date) { Time.parse("2016-01-22T21:50:33Z") }
+      let(:original_dirname) { "foo/bar/baz/" }
       before {
         allow(obj.content).to receive(:createDate) { create_date }
+        allow(obj).to receive(:original_dirname) { original_dirname }
       }
 
       specify {
@@ -118,6 +120,7 @@ module Ddr::Models
         expect(subject[Indexing::MEDIA_TYPE]).to eq "image/tiff"
         expect(subject[Indexing::MEDIA_MAJOR_TYPE]).to eq "image"
         expect(subject[Indexing::MEDIA_SUB_TYPE]).to eq "tiff"
+        expect(subject[Indexing::ORIGINAL_DIRNAME]).to eq original_dirname
       }
 
       describe "streamable object indexing" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -46,4 +46,34 @@ RSpec.describe Item, type: :model do
     }
   end
 
+  describe "original_dirname" do
+    let(:original_dirname) { 'foo/bar/baz' }
+    describe "no children" do
+      specify {
+        allow(subject).to receive(:children) { [ ] }
+        expect(subject.original_dirname).to be_nil
+      }
+    end
+    describe "one child" do
+      describe "child has original filepath" do
+        specify {
+          allow(subject).to receive(:children) { [ Component.new(original_dirname: original_dirname) ] }
+          expect(subject.original_dirname).to eq(original_dirname)
+        }
+      end
+      describe "child does not have original filepath" do
+        specify {
+          allow(subject).to receive(:children) { [ Component.new ] }
+          expect(subject.original_dirname).to be_nil
+        }
+      end
+    end
+    describe "more than one child" do
+      specify {
+        allow(subject).to receive(:children) { [ Component.new(original_dirname: original_dirname),
+                                                 Component.new ] }
+        expect(subject.original_dirname).to be_nil
+      }
+    end
+  end
 end


### PR DESCRIPTION
Also makes the attribute available on the Item if the Item has one Component.