### PR TITLE
Add Component datastream for caption file.  DDR-1124.

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -5,6 +5,7 @@
 #
 class Component < Ddr::Models::Base
 
+  include Ddr::Models::Captionable
   include Ddr::Models::HasContent
   include Ddr::Models::HasIntermediateFile
   include Ddr::Models::HasMultiresImage
@@ -53,7 +54,9 @@ class Component < Ddr::Models::Base
                               Ddr::Datastreams::INTERMEDIATE_FILE) if has_intermediate_file?
     add_service_file_uses_to_default_structure(structure, filegrp, div)
     add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_THUMBNAIL_IMAGE,
-                         Ddr::Datastreams::THUMBNAIL) if has_thumbnail?
+                              Ddr::Datastreams::THUMBNAIL) if has_thumbnail?
+    add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_TRANSCRIPT,
+                              Ddr::Datastreams::CAPTION) if captioned?
     structure
   end
 

--- a/config/initializers/active_fedora_base.rb
+++ b/config/initializers/active_fedora_base.rb
@@ -69,6 +69,14 @@ module ActiveFedora
       can_have_thumbnail? && thumbnail.has_content?
     end
 
+    def captionable?
+      datastreams.include? Ddr::Datastreams::CAPTION
+    end
+
+    def captioned?
+      captionable? && datastreams[Ddr::Datastreams::CAPTION].has_content?
+    end
+
     def can_be_streamable?
       datastreams.include? Ddr::Datastreams::STREAMABLE_MEDIA
     end

--- a/lib/ddr/datastreams.rb
+++ b/lib/ddr/datastreams.rb
@@ -5,6 +5,7 @@ module Ddr
     extend ActiveSupport::Autoload
 
     ADMIN_METADATA    = "adminMetadata"
+    CAPTION           = "caption"
     CONTENT           = "content"
     DC                = "DC"
     DESC_METADATA     = "descMetadata"
@@ -29,6 +30,7 @@ module Ddr
     CHECKSUM_TYPES = [ CHECKSUM_TYPE_MD5, CHECKSUM_TYPE_SHA1, CHECKSUM_TYPE_SHA256, CHECKSUM_TYPE_SHA384, CHECKSUM_TYPE_SHA512 ]
 
     autoload :AdministrativeMetadataDatastream
+    autoload :CaptionDatastream
     autoload :ContentDatastream
     autoload :DatastreamBehavior
     autoload :DeleteExternalFiles

--- a/lib/ddr/datastreams/caption_datastream.rb
+++ b/lib/ddr/datastreams/caption_datastream.rb
@@ -1,0 +1,5 @@
+module Ddr::Datastreams
+  class CaptionDatastream < ExternalFileDatastream
+
+  end
+end

--- a/lib/ddr/models.rb
+++ b/lib/ddr/models.rb
@@ -37,6 +37,7 @@ module Ddr
     autoload :AdminSet
     autoload :Base
     autoload :Cache
+    autoload :Captionable
     autoload :ChecksumInvalid, 'ddr/models/error'
     autoload :Contact
     autoload :ContentModelError, 'ddr/models/error'
@@ -143,6 +144,7 @@ module Ddr
         '.mp3'  => 'audio/mpeg',
         '.ogg'  => 'audio/ogg',
         '.oga'  => 'audio/ogg',
+        '.vtt'  => 'text/vtt',
       }
     end
 

--- a/lib/ddr/models/captionable.rb
+++ b/lib/ddr/models/captionable.rb
@@ -1,0 +1,18 @@
+module Ddr::Models
+  module Captionable
+    extend ActiveSupport::Concern
+
+    included do
+      has_file_datastream name: Ddr::Datastreams::CAPTION,
+                          type: Ddr::Datastreams::CaptionDatastream,
+                          versionable: true,
+                          label: "Caption file for this object",
+                          control_group: "E"
+    end
+
+    def caption_path
+      datastreams[Ddr::Datastreams::CAPTION].file_path
+    end
+
+  end
+end

--- a/lib/ddr/models/solr_document.rb
+++ b/lib/ddr/models/solr_document.rb
@@ -233,6 +233,16 @@ module Ddr::Models
       end
     end
 
+    def captionable?
+      has_datastream?(Ddr::Datastreams::CAPTION)
+    end
+
+    def caption_path
+      if captionable?
+        Ddr::Utils.path_from_uri(datastreams[Ddr::Datastreams::CAPTION]["dsLocation"])
+      end
+    end
+
     def streamable?
       has_datastream?(Ddr::Datastreams::STREAMABLE_MEDIA)
     end

--- a/spec/fixtures/abcd1234.vtt
+++ b/spec/fixtures/abcd1234.vtt
@@ -1,0 +1,38 @@
+WEBVTT
+
+00:01.835 --> 00:02.736
+Lorem ipsum dolor sit amet.
+
+00:02.736 --> 00:03.837
+Vestibulum pretium ligula quis nunc commodo dictum.
+
+00:03.837 --> 00:04.637
+Donec sit amet eros rutrum, elementum neque vitae, volutpat sapien.
+
+00:04.637 --> 00:05.939
+Vivamus sed turpis ut nisi cursus volutpat in non arcu.
+
+00:05.939 --> 00:07.574
+Praesent dignissim lectus sed dignissim ultricies.
+
+00:07.574 --> 00:08.942
+>> ♪ Quisque eget neque maximus, lobortis sem quis, dapibus ipsum.
+
+00:08.942 --> 00:09.542
+Pellentesque eu risus id tellus placerat maximus.
+
+00:09.542 --> 00:11.778
+♪ Proin dapibus purus et magna euismod, non vestibulum ligula pellentesque.
+
+00:11.778 --> 00:13.980
+Vivamus porttitor nibh eget nunc semper, ac tristique arcu scelerisque.
+
+00:13.980 --> 00:15.882
+♪ Maecenas gravida justo sit amet urna scelerisque, eget porttitor mauris interdum.
+
+00:15.882 --> 00:18.752
+Pellentesque consectetur lacus eget bibendum rutrum.
+
+00:18.752 --> 00:20.387
+♪ Quisque semper magna ultrices libero iaculis fermentum.
+

--- a/spec/models/active_fedora_base_spec.rb
+++ b/spec/models/active_fedora_base_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe ActiveFedora::Base do
     end
   end
 
+  its(:captionable?) { is_expected.to be false }
+  it { is_expected.not_to be_captioned }
+
   its(:can_be_streamable?) { is_expected.to be false }
   it { is_expected.not_to be_streamable }
 

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Component, type: :model, components: true do
   it_behaves_like "it has an association", :belongs_to, :target, :has_external_target, "Target"
   it_behaves_like "a non-collection model"
   it_behaves_like "a potentially publishable object"
+  it_behaves_like "an object that can be captioned"
   it_behaves_like "an object that can have an intermediate file"
   it_behaves_like "an object that can be streamable"
 
@@ -77,6 +78,22 @@ RSpec.describe Component, type: :model, components: true do
         describe "with neither multires image nor streamable media" do
           it "has the correct structure file" do
             expect(service_files).to contain_exactly(Ddr::Datastreams::CONTENT)
+          end
+        end
+      end
+      describe "transcript" do
+        describe "with caption file" do
+          before do
+            allow(subject).to receive(:captioned?) { true }
+          end
+          it "has the correct structure file" do
+            expect(struct.uses[Ddr::Models::Structure::USE_TRANSCRIPT].first.href)
+                .to eq(Ddr::Datastreams::CAPTION)
+          end
+        end
+        describe "without caption file" do
+          it "has the correct structure file" do
+            expect(struct.uses[Ddr::Models::Structure::USE_TRANSCRIPT]).to be nil
           end
         end
       end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -207,6 +207,30 @@ EOS
     }
   end
 
+  describe "#captionable?" do
+    specify {
+      allow(subject).to receive(:has_datastream?).with(Ddr::Datastreams::CAPTION) { false }
+      expect(subject).not_to be_captionable
+    }
+    specify {
+      allow(subject).to receive(:has_datastream?).with(Ddr::Datastreams::CAPTION) { true }
+      expect(subject).to be_captionable
+    }
+  end
+
+  describe "#caption_path" do
+    specify {
+      allow(subject).to receive(:captionable?) { false }
+      expect(subject.caption_path).to be_nil
+    }
+    specify {
+      allow(subject).to receive(:datastreams) do
+        {"caption"=>{"dsLocation"=>"file:/foo/bar/baz.txt"}}
+      end
+      expect(subject.caption_path).to eq "/foo/bar/baz.txt"
+    }
+  end
+
   describe "#streamable?" do
     specify {
       allow(subject).to receive(:has_datastream?).with(Ddr::Datastreams::STREAMABLE_MEDIA) { false }

--- a/spec/support/shared_examples_for_captionable.rb
+++ b/spec/support/shared_examples_for_captionable.rb
@@ -1,0 +1,21 @@
+RSpec.shared_examples "an object that cannot be captioned" do
+  it { is_expected.to_not be_captioned }
+  its(:captionable?) { is_expected.to be false }
+end
+
+RSpec.shared_examples "an object that can be captioned" do
+  it { is_expected.to_not be_captioned }
+  its(:captionable?) { is_expected.to be true }
+
+  describe "when caption file is present" do
+    before {
+      subject.add_file(fixture_file_upload('abcd1234.vtt', 'text/vtt'), 'caption')
+      subject.save!
+    }
+    specify {
+      expect(subject).to be_captioned
+      expect(subject.caption_path).to be_present
+      expect(subject.caption_path).to eq subject.caption.file_path
+    }
+  end
+end


### PR DESCRIPTION
Caption datastream will have use 'Transcript' in component structural metadata.

Upgrade Note: Add entry for Ddr::Datastreams::CaptionDatastream.file_store to appropriate environment(s).