### PR TITLE
An object's default structure is now always an XML document; DDR-1154.

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -53,9 +53,7 @@ class Collection < Ddr::Models::Base
   end
 
   def default_structure
-    if items.present?
-      build_default_structure
-    end
+    build_default_structure
   end
 
   private

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -31,7 +31,7 @@ class Component < Ddr::Models::Base
   end
 
   def default_structure
-    build_default_structure if has_content?
+    build_default_structure
   end
 
   private
@@ -42,21 +42,24 @@ class Component < Ddr::Models::Base
     metshdr = structure.add_metshdr
     structure.add_agent(parent: metshdr, role: Ddr::Models::Structures::Agent::ROLE_CREATOR,
                         name: Ddr::Models::Structures::Agent::NAME_REPOSITORY_DEFAULT)
-    filesec = structure.add_filesec
     structmap = structure.add_structmap(type: Ddr::Models::Structure::TYPE_DEFAULT)
-    div = structure.add_div(parent: structmap)
-    filegrp = structure.add_filegrp(parent: filesec)
-    add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_ORIGINAL_FILE,
-                              Ddr::Datastreams::CONTENT)
-    add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_PRESERVATION_MASTER_FILE,
-                              Ddr::Datastreams::CONTENT)
-    add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_INTERMEDIATE_FILE,
-                              Ddr::Datastreams::INTERMEDIATE_FILE) if has_intermediate_file?
-    add_service_file_uses_to_default_structure(structure, filegrp, div)
-    add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_THUMBNAIL_IMAGE,
-                              Ddr::Datastreams::THUMBNAIL) if has_thumbnail?
-    add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_TRANSCRIPT,
-                              Ddr::Datastreams::CAPTION) if captioned?
+    if has_content?
+      filesec = structure.add_filesec
+      div = structure.add_div(parent: structmap)
+      filegrp = structure.add_filegrp(parent: filesec)
+      add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_ORIGINAL_FILE,
+                           Ddr::Datastreams::CONTENT)
+      add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_PRESERVATION_MASTER_FILE,
+                           Ddr::Datastreams::CONTENT)
+      add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_INTERMEDIATE_FILE,
+                           Ddr::Datastreams::INTERMEDIATE_FILE) if has_intermediate_file?
+      add_service_file_uses_to_default_structure(structure, filegrp, div)
+      add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_THUMBNAIL_IMAGE,
+                           Ddr::Datastreams::THUMBNAIL) if has_thumbnail?
+      add_use_to_structure(structure, filegrp, div, Ddr::Models::Structure::USE_TRANSCRIPT,
+                           Ddr::Datastreams::CAPTION) if captioned?
+
+    end
     structure
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -40,9 +40,7 @@ class Item < Ddr::Models::Base
   end
 
   def default_structure
-    if components.present?
-      build_default_structure
-    end
+    build_default_structure
   end
 
   private

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -106,8 +106,21 @@ RSpec.describe Collection, type: :model do
       allow(SecureRandom).to receive(:uuid).and_return("abc-def", "ghi-jkl", "mno-pqr", "stu-vwx", "yza-bcd", "efg-hij")
     end
     describe "when the collection has no items" do
-      it "should be nil" do
-        expect(subject.default_structure).to be_nil
+      let(:expected) do
+        xml = <<-EOS
+            <mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <metsHdr>
+                <agent ROLE="#{Ddr::Models::Structures::Agent::ROLE_CREATOR}">
+                  <name>#{Ddr::Models::Structures::Agent::NAME_REPOSITORY_DEFAULT}</name>
+                </agent>
+              </metsHdr>
+              <structMap TYPE="#{Ddr::Models::Structure::TYPE_DEFAULT}" />
+            </mets>
+        EOS
+        xml
+      end
+      it "should be the appropriate structure" do
+        expect(subject.default_structure.to_xml).to be_equivalent_to(expected)
       end
     end
     describe "when the collection has items" do

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -20,8 +20,21 @@ RSpec.describe Component, type: :model, components: true do
 
   describe "default structure" do
     describe "no content" do
-      it "should be nil" do
-        expect(subject.default_structure).to be_nil
+      let(:expected) do
+        xml = <<-EOS
+            <mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <metsHdr>
+                <agent ROLE="#{Ddr::Models::Structures::Agent::ROLE_CREATOR}">
+                  <name>#{Ddr::Models::Structures::Agent::NAME_REPOSITORY_DEFAULT}</name>
+                </agent>
+              </metsHdr>
+              <structMap TYPE="#{Ddr::Models::Structure::TYPE_DEFAULT}" />
+            </mets>
+        EOS
+        xml
+      end
+      it "should be the appropriate structure" do
+        expect(described_class.new.default_structure.to_xml).to be_equivalent_to(expected)
       end
     end
     describe "has content" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -48,8 +48,21 @@ RSpec.describe Item, type: :model do
 
   describe "#default_structure" do
     describe "when the item has no components" do
-      it "should be nil" do
-        expect(subject.default_structure).to be_nil
+      let(:expected) do
+        xml = <<-EOS
+            <mets xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <metsHdr>
+                <agent ROLE="#{Ddr::Models::Structures::Agent::ROLE_CREATOR}">
+                  <name>#{Ddr::Models::Structures::Agent::NAME_REPOSITORY_DEFAULT}</name>
+                </agent>
+              </metsHdr>
+              <structMap TYPE="#{Ddr::Models::Structure::TYPE_DEFAULT}" />
+            </mets>
+        EOS
+        xml
+      end
+      it "should be the appropriate structure" do
+        expect(subject.default_structure.to_xml).to be_equivalent_to(expected)
       end
     end
     describe "when the item has components" do


### PR DESCRIPTION
Previously, when an object had no structurally relevant associations, the 'default_structure'
method returned nil.  Now, it returns a METS document with an empty structMap element.