### PR TITLE
Notify when datastream created; identify structurally relevant datast…

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -18,6 +18,10 @@ class Component < Ddr::Models::Base
   alias_method :item, :parent
   alias_method :item=, :parent=
 
+  STRUCTURALLY_RELEVANT_DATASTREAMS = [ Ddr::Datastreams::CAPTION, Ddr::Datastreams::CONTENT,
+                                        Ddr::Datastreams::INTERMEDIATE_FILE, Ddr::Datastreams::MULTIRES_IMAGE,
+                                        Ddr::Datastreams::STREAMABLE_MEDIA, Ddr::Datastreams::THUMBNAIL ]
+
   def collection
     self.parent.parent rescue nil
   end

--- a/lib/ddr/datastreams.rb
+++ b/lib/ddr/datastreams.rb
@@ -18,6 +18,7 @@ module Ddr
     STRUCT_METADATA   = "structMetadata"
     THUMBNAIL         = "thumbnail"
 
+    CREATE = "create.repo_file"
     SAVE = "save.repo_file"
     DELETE = "delete.repo_file"
 

--- a/lib/ddr/datastreams/datastream_behavior.rb
+++ b/lib/ddr/datastreams/datastream_behavior.rb
@@ -8,6 +8,7 @@ module Ddr
       STRFTIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%LZ"
 
       included do
+        after_create :notify_create
         around_save :notify_save
         around_destroy :notify_delete
       end
@@ -128,6 +129,10 @@ module Ddr
           profile: profile.dup,
           version_history: version_history
         )
+      end
+
+      def notify_create
+        ActiveSupport::Notifications.instrument(Ddr::Datastreams::CREATE, default_notification_payload)
       end
 
       def notify_save

--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -149,7 +149,7 @@ module Ddr
                  permanent_id: permanent_id,
                  model: self.class.to_s,
                  parent: parent_id,
-                 skip_update_parent_structure: cache.fetch(:skip_update_parent_structure, false))
+                 skip_structure_updates: cache.fetch(:skip_structure_updates, false))
       end
 
       def notify_ingest


### PR DESCRIPTION
…reams; partially addresses DDR-1148.

Also renames save option to suppress structural metadata updating to make it more generic.