### PR TITLE
Updates FITS test fixtures to FITS 1.2.0 output.

### DIFF
--- a/lib/ddr/datastreams/content_datastream.rb
+++ b/lib/ddr/datastreams/content_datastream.rb
@@ -1,5 +1,17 @@
 module Ddr::Datastreams
   class ContentDatastream < ExternalFileDatastream
 
+    CONTENT_CHANGED = "content_changed.content.repo_file"
+
+    around_save :notify_content_changed, if: [:external?, :dsLocation_changed?]
+
+    private
+
+    def notify_content_changed
+      ActiveSupport::Notifications.instrument(CONTENT_CHANGED, pid: pid) do |payload|
+        yield
+      end
+    end
+
   end
 end

--- a/spec/fixtures/fits/document.xml
+++ b/spec/fixtures/fits/document.xml
@@ -1,65 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.8.5" timestamp="7/3/15 8:29 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.0" timestamp="10/17/17 5:48 PM">
   <identification>
-    <identity format="Portable Document Format" mimetype="application/pdf" toolname="FITS" toolversion="0.8.5">
-      <tool toolname="Jhove" toolversion="1.5" />
-      <tool toolname="file utility" toolversion="5.04" />
-      <tool toolname="Exiftool" toolversion="9.13" />
-      <tool toolname="Droid" toolversion="6.1.3" />
-      <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" />
+    <identity format="Portable Document Format" mimetype="application/pdf" toolname="FITS" toolversion="1.2.0">
+      <tool toolname="Droid" toolversion="6.3" />
+      <tool toolname="Jhove" toolversion="1.16" />
+      <tool toolname="file utility" toolversion="5.25" />
+      <tool toolname="Exiftool" toolversion="10.00" />
+      <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
       <tool toolname="ffident" toolversion="0.2" />
-      <tool toolname="Tika" toolversion="1.3" />
-      <version toolname="Jhove" toolversion="1.5">1.6</version>
-      <externalIdentifier toolname="Droid" toolversion="6.1.3" type="puid">fmt/20</externalIdentifier>
+      <tool toolname="Tika" toolversion="1.10" />
+      <version toolname="Droid" toolversion="6.3">1.6</version>
+      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/20</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.5">3786205</size>
-    <creatingApplicationName toolname="Exiftool" toolversion="9.13" status="CONFLICT">Adobe Acrobat Pro 11.0.3 Paper Capture Plug-in/PREMIS Editorial Committee</creatingApplicationName>
-    <creatingApplicationName toolname="NLNZ Metadata Extractor" toolversion="3.4GA" status="CONFLICT">Adobe Acrobat Pro 11.0.3 Paper Capture Plug-in/Acrobat PDFMaker 11 for Word</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="9.13" status="CONFLICT">2015:06:25 21:45:24-04:00</lastmodified>
-    <lastmodified toolname="Tika" toolversion="1.3" status="CONFLICT">2015-06-08T21:22:35Z</lastmodified>
-    <created toolname="Exiftool" toolversion="9.13" status="SINGLE_RESULT">2015:06:05 15:16:23-04:00</created>
+    <size toolname="Jhove" toolversion="1.16">2176353</size>
+    <creatingApplicationName toolname="Exiftool" toolversion="10.00">Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word</creatingApplicationName>
+    <lastmodified toolname="Exiftool" toolversion="10.00" status="CONFLICT">2016:01:07 09:49:50-05:00</lastmodified>
+    <lastmodified toolname="Tika" toolversion="1.10" status="CONFLICT">2016-01-07T14:49:50Z</lastmodified>
+    <created toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2015:12:09 13:23:09-05:00</created>
     <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dc/Downloads/premis-3-0-final.pdf</filepath>
     <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">premis-3-0-final.pdf</filename>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">432ab76d650bfdc8f8d4a98cea9634bb</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1435283124000</fslastmodified>
+    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">58fee04df34490ee7ecf3cdd5ddafc72</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1508276630000</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">false</valid>
-    <message toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">Invalid page tree node offset=390028</message>
-    <message toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">Outlines contain recursive references.</message>
+    <well-formed toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <document>
-      <title toolname="Jhove" toolversion="1.5" status="CONFLICT">CONTENTS</title>
-      <title toolname="Exiftool" toolversion="9.13" status="CONFLICT">PREMIS Data Dictionary for Preservation Metadata, Version 3.0</title>
-      <author toolname="Exiftool" toolversion="9.13">PREMIS Editorial Committee</author>
-      <language toolname="Jhove" toolversion="1.5">en</language>
-      <pageCount toolname="Exiftool" toolversion="9.13">282</pageCount>
-      <isTagged toolname="Jhove" toolversion="1.5" status="CONFLICT">no</isTagged>
-      <isTagged toolname="NLNZ Metadata Extractor" toolversion="3.4GA" status="CONFLICT">yes</isTagged>
-      <hasOutline toolname="Jhove" toolversion="1.5">yes</hasOutline>
-      <hasAnnotations toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">no</hasAnnotations>
-      <isRightsManaged toolname="Exiftool" toolversion="9.13" status="SINGLE_RESULT">no</isRightsManaged>
-      <isProtected toolname="Exiftool" toolversion="9.13">no</isProtected>
-      <hasForms toolname="NLNZ Metadata Extractor" toolversion="3.4GA" status="SINGLE_RESULT">yes</hasForms>
-      <subject toolname="Tika" toolversion="1.3" status="SINGLE_RESULT">PREMIS</subject>
+      <title toolname="Exiftool" toolversion="10.00">PREMIS Data Dictionary for Preservation Metadata, Version 3.0</title>
+      <author toolname="Exiftool" toolversion="10.00">PREMIS Editorial Committee</author>
+      <language toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">en</language>
+      <pageCount toolname="Exiftool" toolversion="10.00">283</pageCount>
+      <isTagged toolname="Exiftool" toolversion="10.00" status="CONFLICT">yes</isTagged>
+      <isTagged toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">no</isTagged>
+      <hasOutline toolname="Jhove" toolversion="1.16">no</hasOutline>
+      <hasAnnotations toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">no</hasAnnotations>
+      <subject toolname="Exiftool" toolversion="10.00" status="CONFLICT">PREMIS, Data Dictionary, Version 3.0, preservation metadata, library of congress</subject>
+      <subject toolname="Tika" toolversion="1.10" status="CONFLICT">PREMIS Data Dictionary, Version 3.0</subject>
+      <description toolname="Exiftool" toolversion="10.00">PREMIS Data Dictionary, Version 3.0</description>
+      <hasForms toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">no</hasForms>
     </document>
   </metadata>
-  <statistics fitsExecutionTime="2977">
+  <statistics fitsExecutionTime="1373">
+    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Jhove" toolversion="1.5" executionTime="1034" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="912" />
-    <tool toolname="Exiftool" toolversion="9.13" executionTime="842" />
-    <tool toolname="Droid" toolversion="6.1.3" executionTime="336" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" executionTime="2192" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="351" />
+    <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="Droid" toolversion="6.3" executionTime="144" />
+    <tool toolname="Jhove" toolversion="1.16" executionTime="488" />
+    <tool toolname="file utility" toolversion="5.25" executionTime="471" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="479" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="454" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="141" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="410" />
-    <tool toolname="Tika" toolversion="1.3" executionTime="2911" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="449" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="1337" />
   </statistics>
 </fits>
 

--- a/spec/fixtures/fits/image.xml
+++ b/spec/fixtures/fits/image.xml
@@ -1,59 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="0.8.5" timestamp="7/28/15 4:34 PM">
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.2.0" timestamp="10/17/17 5:47 PM">
   <identification>
-    <identity format="JPEG File Interchange Format" mimetype="image/jpeg" toolname="FITS" toolversion="0.8.5">
-      <tool toolname="Jhove" toolversion="1.5" />
-      <tool toolname="file utility" toolversion="5.04" />
-      <tool toolname="Exiftool" toolversion="9.13" />
-      <tool toolname="Droid" toolversion="6.1.3" />
-      <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" />
-      <version toolname="Jhove" toolversion="1.5">1.01</version>
-      <externalIdentifier toolname="Droid" toolversion="6.1.3" type="puid">fmt/43</externalIdentifier>
+    <identity format="JPEG File Interchange Format" mimetype="image/jpeg" toolname="FITS" toolversion="1.2.0">
+      <tool toolname="Droid" toolversion="6.3" />
+      <tool toolname="Jhove" toolversion="1.16" />
+      <tool toolname="file utility" toolversion="5.25" />
+      <tool toolname="Exiftool" toolversion="10.00" />
+      <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
+      <version toolname="Droid" toolversion="6.3">1.01</version>
+      <externalIdentifier toolname="Droid" toolversion="6.3" type="puid">fmt/43</externalIdentifier>
     </identity>
   </identification>
   <fileinfo>
-    <size toolname="Jhove" toolversion="1.5">94497</size>
-    <creatingApplicationName toolname="Jhove" toolversion="1.5">File source: https://commons.wikimedia.org/wiki/File:Dante_Gabriel_Rossetti_-_Joan_of_Arc_(1882).jpg</creatingApplicationName>
-    <lastmodified toolname="Exiftool" toolversion="9.13" status="SINGLE_RESULT">2015:07:28 10:19:55-04:00</lastmodified>
-    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dc/Downloads/Joan_of_Arc.jpg</filepath>
-    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Joan_of_Arc.jpg</filename>
-    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">bc575fbcbffff0248f5da3dddf8afd69</md5checksum>
-    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1438093195000</fslastmodified>
+    <size toolname="Jhove" toolversion="1.16">97220</size>
+    <creatingApplicationName toolname="Jhove" toolversion="1.16">File source: https://commons.wikimedia.org/wiki/File:Dante_Gabriel_Rossetti_-_Joan_of_Arc_(1882).jpg</creatingApplicationName>
+    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/Users/dc/Downloads/Dante_Gabriel_Rossetti_-_Joan_of_Arc_(1882).jpg</filepath>
+    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">Dante_Gabriel_Rossetti_-_Joan_of_Arc_(1882).jpg</filename>
+    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">c21d5fecf9d0310858d2bfe44e5436ce</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1508276690000</fslastmodified>
   </fileinfo>
   <filestatus>
-    <well-formed toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">true</well-formed>
-    <valid toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">true</valid>
+    <well-formed toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">true</well-formed>
+    <valid toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">true</valid>
   </filestatus>
   <metadata>
     <image>
-      <byteOrder toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">big endian</byteOrder>
-      <compressionScheme toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">JPEG (old-style)</compressionScheme>
-      <imageWidth toolname="Jhove" toolversion="1.5">500</imageWidth>
-      <imageHeight toolname="Jhove" toolversion="1.5">569</imageHeight>
-      <colorSpace toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">YCbCr</colorSpace>
-      <iccProfileName toolname="Exiftool" toolversion="9.13" status="SINGLE_RESULT">c2</iccProfileName>
-      <YCbCrSubSampling toolname="Exiftool" toolversion="9.13" status="SINGLE_RESULT">1 1</YCbCrSubSampling>
-      <samplingFrequencyUnit toolname="Jhove" toolversion="1.5">in.</samplingFrequencyUnit>
-      <xSamplingFrequency toolname="Jhove" toolversion="1.5">128</xSamplingFrequency>
-      <ySamplingFrequency toolname="Jhove" toolversion="1.5">128</ySamplingFrequency>
-      <bitsPerSample toolname="Jhove" toolversion="1.5">8 8 8</bitsPerSample>
-      <samplesPerPixel toolname="Jhove" toolversion="1.5" status="SINGLE_RESULT">3</samplesPerPixel>
-      <lightSource toolname="NLNZ Metadata Extractor" toolversion="3.4GA" status="SINGLE_RESULT">unknown</lightSource>
-      <iccProfileVersion toolname="Exiftool" toolversion="9.13" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
+      <byteOrder toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">big endian</byteOrder>
+      <compressionScheme toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">JPEG</compressionScheme>
+      <imageWidth toolname="Jhove" toolversion="1.16">512</imageWidth>
+      <imageHeight toolname="Exiftool" toolversion="10.00">583</imageHeight>
+      <colorSpace toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">YCbCr</colorSpace>
+      <iccProfileName toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">c2</iccProfileName>
+      <YCbCrSubSampling toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">1 1</YCbCrSubSampling>
+      <samplingFrequencyUnit toolname="Jhove" toolversion="1.16">in.</samplingFrequencyUnit>
+      <xSamplingFrequency toolname="Exiftool" toolversion="10.00">128</xSamplingFrequency>
+      <ySamplingFrequency toolname="Exiftool" toolversion="10.00">128</ySamplingFrequency>
+      <bitsPerSample toolname="Jhove" toolversion="1.16">8 8 8</bitsPerSample>
+      <samplesPerPixel toolname="Jhove" toolversion="1.16" status="SINGLE_RESULT">3</samplesPerPixel>
+      <lightSource toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">unknown</lightSource>
+      <iccProfileVersion toolname="Exiftool" toolversion="10.00" status="SINGLE_RESULT">2.1.0</iccProfileVersion>
     </image>
   </metadata>
-  <statistics fitsExecutionTime="897">
+  <statistics fitsExecutionTime="722">
+    <tool toolname="MediaInfo" toolversion="0.7.75" status="did not run" />
     <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
     <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
-    <tool toolname="Jhove" toolversion="1.5" executionTime="728" />
-    <tool toolname="file utility" toolversion="5.04" executionTime="662" />
-    <tool toolname="Exiftool" toolversion="9.13" executionTime="718" />
-    <tool toolname="Droid" toolversion="6.1.3" executionTime="85" />
-    <tool toolname="NLNZ Metadata Extractor" toolversion="3.4GA" executionTime="664" />
-    <tool toolname="OIS File Information" toolversion="0.2" executionTime="82" />
+    <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
+    <tool toolname="Droid" toolversion="6.3" executionTime="151" />
+    <tool toolname="Jhove" toolversion="1.16" executionTime="644" />
+    <tool toolname="file utility" toolversion="5.25" executionTime="545" />
+    <tool toolname="Exiftool" toolversion="10.00" executionTime="629" />
+    <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="592" />
+    <tool toolname="OIS File Information" toolversion="0.2" executionTime="148" />
     <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
-    <tool toolname="ffident" toolversion="0.2" executionTime="315" />
-    <tool toolname="Tika" toolversion="1.3" executionTime="240" />
+    <tool toolname="ffident" toolversion="0.2" executionTime="537" />
+    <tool toolname="Tika" toolversion="1.10" executionTime="635" />
   </statistics>
 </fits>
 

--- a/spec/managers/technical_metadata_manager_spec.rb
+++ b/spec/managers/technical_metadata_manager_spec.rb
@@ -39,23 +39,23 @@ module Ddr::Managers
 
       its(:fits?) { is_expected.to be true }
 
-      its(:created) { is_expected.to eq(["2015:06:05 15:16:23-04:00"]) }
-      its(:creating_application) { is_expected.to contain_exactly("Adobe Acrobat Pro 11.0.3 Paper Capture Plug-in/PREMIS Editorial Committee", "Adobe Acrobat Pro 11.0.3 Paper Capture Plug-in/Acrobat PDFMaker 11 for Word") }
-      its(:extent) { is_expected.to eq(["3786205"]) }
-      its(:file_size) { is_expected.to eq([3786205]) }
-      its(:fits_version) { is_expected.to eq("0.8.5") }
+      its(:created) { is_expected.to eq(["2015:12:09 13:23:09-05:00"]) }
+      its(:creating_application) { is_expected.to contain_exactly("Adobe PDF Library 11.0/Acrobat PDFMaker 11 for Word") }
+      its(:extent) { is_expected.to eq(["2176353"]) }
+      its(:file_size) { is_expected.to eq([2176353]) }
+      its(:fits_version) { is_expected.to eq("1.2.0") }
       its(:format_label) { is_expected.to eq(["Portable Document Format"]) }
       its(:format_version) { is_expected.to eq(["1.6"]) }
-      its(:last_modified) { is_expected.to eq(["2015-06-08T21:22:35Z"]) }
-      its(:md5) { is_expected.to eq("432ab76d650bfdc8f8d4a98cea9634bb") }
+      its(:last_modified) { is_expected.to eq(["2016-01-07T14:49:50Z"]) }
+      its(:md5) { is_expected.to eq("58fee04df34490ee7ecf3cdd5ddafc72") }
       its(:media_type) { is_expected.to eq(["application/pdf"]) }
       its(:pronom_identifier) { is_expected.to eq(["fmt/20"]) }
-      its(:valid) { is_expected.to eq(["false"]) }
+      its(:valid) { is_expected.to eq(["true"]) }
       its(:well_formed) { is_expected.to eq(["true"]) }
 
       describe "datetime fields" do
-        its(:creation_time) { is_expected.to contain_exactly(DateTime.parse("2015-06-05 15:16:23-04:00").to_time.utc) }
-        its(:modification_time) { is_expected.to contain_exactly(DateTime.parse("2015-06-08T21:22:35Z").to_time.utc) }
+        its(:creation_time) { is_expected.to contain_exactly(DateTime.parse("2015-12-09 13:23:09-05:00").to_time.utc) }
+        its(:modification_time) { is_expected.to contain_exactly(DateTime.parse("2016-01-07T14:49:50Z").to_time.utc) }
       end
     end
 
@@ -73,8 +73,8 @@ module Ddr::Managers
       before do
         obj.fits.content = fixture_file_upload(File.join("fits", "image.xml"))
       end
-      its(:image_width) { is_expected.to eq(["500"]) }
-      its(:image_height) { is_expected.to eq(["569"]) }
+      its(:image_width) { is_expected.to eq(["512"]) }
+      its(:image_height) { is_expected.to eq(["583"]) }
       its(:color_space) { is_expected.to eq(["YCbCr"]) }
       its(:icc_profile_name) { is_expected.to eq(["c2"]) }
       its(:icc_profile_version) { is_expected.to eq(["2.1.0"]) }

--- a/spec/support/shared_examples_for_has_content.rb
+++ b/spec/support/shared_examples_for_has_content.rb
@@ -69,6 +69,13 @@ RSpec.shared_examples "an object that can have content" do
           expect_any_instance_of(Ddr::Managers::DerivativesManager).to receive(:update_derivatives)
           subject.save
         end
+        it "should notify that content has changed" do
+          callback = lambda { |*args| args }
+          ActiveSupport::Notifications.subscribed(callback, "content_changed.content.repo_file") do
+            expect(callback).to receive(:call) { nil }
+            subject.save
+          end
+        end
       end
 
       context "and it's an existing object with content" do
@@ -77,6 +84,13 @@ RSpec.shared_examples "an object that can have content" do
         it "should generate derivatives" do
           expect_any_instance_of(Ddr::Managers::DerivativesManager).to receive(:update_derivatives)
           subject.upload! file
+        end
+        it "should notify that content has changed" do
+          callback = lambda { |*args| args }
+          ActiveSupport::Notifications.subscribed(callback, "content_changed.content.repo_file") do
+            expect(callback).to receive(:call) { nil }
+            subject.upload! file
+          end
         end
         context "and it is saved with :skip_update_derivatives=>true" do
           it "does not generate derivatives" do


### PR DESCRIPTION
This was done to confirm that there no changes are required to
metadata mappings.

Adds around_save notification to content datastream.