### PR TITLE
Hotfix 2.9.2

### DIFF
--- a/lib/ddr/datastreams/external_file_datastream.rb
+++ b/lib/ddr/datastreams/external_file_datastream.rb
@@ -16,7 +16,7 @@ module Ddr::Datastreams
     end
 
     def content
-      external? ? File.read(file_path) : super
+      external? && !new? ? File.read(file_path) : super
     end
 
     def file_size

--- a/spec/datastreams/external_file_datastream_spec.rb
+++ b/spec/datastreams/external_file_datastream_spec.rb
@@ -12,6 +12,7 @@ module Ddr::Datastreams
     its(:file_paths) { is_expected.to be_empty }
 
     specify {
+      expect(File).not_to receive(:read).with(file1.path)
       subject.add_file(file1.path, mime_type: file1.content_type)
       obj.save!
       path1 = subject.file_path


### PR DESCRIPTION
Fixes bug in ExternalFileDatastream#content that causes ingest to
fail with a very large file. The fix alters the behavior to read
the external file (with File.read) only if the datastream is
persisted.