### PR TITLE
Fix call to deprecated `Ddr::Models::Base#datastreams_to_validate` me…

### DIFF
--- a/lib/ddr/actions/fixity_check.rb
+++ b/lib/ddr/actions/fixity_check.rb
@@ -12,7 +12,7 @@ module Ddr
       # Return result of fixity check
       def self._execute(object)
         Result.new(pid: object.pid).tap do |r|
-          object.datastreams_to_validate.each do |dsid, ds|
+          object.datastreams_having_content.each do |dsid, ds|
             r.success &&= ds.dsChecksumValid
             r.results[dsid] = ds.profile
           end


### PR DESCRIPTION
…thod.

Call to `Ddr::Models::Base#datastreams_to_validate` replaced with call to `Ddr::Models::Base#datastreams_having_content`
since `#datastreams_to_validate` is aliased to `#datstreams_having_content` in `Ddr::Models::Base`.