### PR TITLE
Use POST instead of GET in Solr requests.

### DIFF
--- a/lib/ddr/index/connection.rb
+++ b/lib/ddr/index/connection.rb
@@ -10,14 +10,14 @@ module Ddr::Index
     module Methods
       extend Forwardable
 
-      delegate [:get, :paginate] => :solr
+      delegate [:get, :post, :paginate] => :solr
 
       def solr
         RSolr.connect(ActiveFedora.solr_config)
       end
 
       def select(params, extra={})
-        Response.new get("select", params: params.merge(extra))
+        Response.new post("select", params: params.merge(extra))
       end
 
       def page(*args)


### PR DESCRIPTION
Fixes DDR-1256.