### PR TITLE
Moves permanent ID minting from after_create to around_save callback.

### DIFF
--- a/lib/ddr/models/base.rb
+++ b/lib/ddr/models/base.rb
@@ -31,10 +31,10 @@ module Ddr
       before_create :set_ingested_by, if: :performed_by, unless: :ingested_by
       before_create :grant_default_roles
 
-      after_create :assign_permanent_id!, if: :assign_permanent_id?
-      after_create :notify_ingest
-
       around_save :notify_update, unless: :new_record?
+      around_save :assign_permanent_id!, if: :assign_permanent_id?, on: :create
+
+      after_create :notify_ingest
 
       around_deaccession :notify_deaccession
       around_destroy :notify_delete
@@ -202,6 +202,7 @@ module Ddr
       end
 
       def assign_permanent_id!
+        yield
         PermanentId.assign!(self)
       end
 

--- a/spec/models/permanent_id_spec.rb
+++ b/spec/models/permanent_id_spec.rb
@@ -11,10 +11,6 @@ module Ddr::Models
           allow(described_class.identifier_class).to receive(:find).with("foo") { id }
           allow(Ddr::Models).to receive(:auto_assign_permanent_id) { true }
         end
-        after do
-          obj.permanent_id = nil
-          obj.save!
-        end
         it "assigns a permanent id to the object" do
           obj.reload
           expect(obj.permanent_id).to eq("foo")


### PR DESCRIPTION
This should correct timing issues affecting structural metadata
generation per DDR-1391.