### PR TITLE
Hotfix 2.10.1

### DIFF
--- a/ddr-models.gemspec
+++ b/ddr-models.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ezid-client", "~> 1.6"
   s.add_dependency "resque", "~> 1.25"
   s.add_dependency "rdf-vocab", "~> 0.8"
-  s.add_dependency "net-ldap", "~> 0.11"
+  s.add_dependency "net-ldap", "~> 0.16"
   s.add_dependency "cancancan", "~> 1.12"
   s.add_dependency "ddr-antivirus", "~> 2.1.1"
   s.add_dependency "virtus", "~> 1.0.5"

--- a/lib/ddr/models/version.rb
+++ b/lib/ddr/models/version.rb
@@ -1,5 +1,5 @@
 module Ddr
   module Models
-    VERSION = "2.10.0"
+    VERSION = "2.10.1"
   end
 end


### PR DESCRIPTION
Upgrades net-ldap to ~> 0.16.

Addresses reported security vulnerability.